### PR TITLE
Backend posts deletion functionality

### DIFF
--- a/backend/src/apps/posts/__test__/fixtures/mock-db-client.js
+++ b/backend/src/apps/posts/__test__/fixtures/mock-db-client.js
@@ -11,6 +11,13 @@ let updateSpy = vi.fn(() => {
     }),
   };
 });
+let deleteSpy = vi.fn(() => {
+  return {
+    eq: vi.fn(() => {
+      return { data: null, error: null };
+    }),
+  };
+});
 let insertSpy = vi.fn(() => {
   return {
     select: vi.fn(() => {
@@ -47,6 +54,7 @@ const mockTestDbClient = {
       select: selectSpy,
       insert: insertSpy,
       update: updateSpy,
+      delete: deleteSpy,
     };
   }),
 };

--- a/backend/src/apps/posts/data-access/posts-db.js
+++ b/backend/src/apps/posts/data-access/posts-db.js
@@ -51,7 +51,11 @@ export default function makePostsDb({ dbClient }) {
       .eq("id", updateDetails.id);
     return { ...result };
   }
-  async function remove() {}
+  async function remove(postId) {
+    let result = await dbClient.from("posts").delete().eq("id", postId);
+    console.log(result);
+    return { ...result };
+  }
   async function insert(insertDetails) {
     let result = await dbClient
       .from("posts") // TODO: Add .env for "posts"

--- a/backend/src/apps/posts/domain/use-cases/index.js
+++ b/backend/src/apps/posts/domain/use-cases/index.js
@@ -6,6 +6,7 @@ import makeImage from "../entities/image/index.js";
 import makeHandleAttachmentPreview from "./handle-attachment-preview.js";
 import makeUpdatePost from "./update-post.js";
 import { postsDb, imagesDb } from "../../data-access/index.js";
+import makeRemovePost from "./remove-post.js";
 
 const createPost = makeCreatePost({
   postsDb,
@@ -18,6 +19,7 @@ const handleAttachmentPreview = makeHandleAttachmentPreview({
   makeImage,
 });
 const updatePost = makeUpdatePost({ postsDb });
+const removePost = makeRemovePost({ postsDb });
 const postService = Object.freeze({
   createPost,
   handleAttachmentPreview,
@@ -32,4 +34,5 @@ export {
   retrievePosts,
   retrieveSinglePost,
   updatePost,
+  removePost,
 };

--- a/backend/src/apps/posts/domain/use-cases/remove-post.js
+++ b/backend/src/apps/posts/domain/use-cases/remove-post.js
@@ -1,0 +1,13 @@
+import makePost from "../entities/post/index.js";
+export default function makeRemovePost({ postsDb }) {
+  return async function removePost(postDetails) {
+    const post = makePost(postDetails);
+    let { error } = await postsDb.remove(post.getId());
+    if (error) {
+      throw new Error(
+        `Error deleting post from database: ${error.message}. Post deletion failed.`
+      );
+    }
+    return { ...post.getDTO() };
+  };
+}

--- a/backend/src/apps/posts/domain/use-cases/remove-post.spec.js
+++ b/backend/src/apps/posts/domain/use-cases/remove-post.spec.js
@@ -1,0 +1,33 @@
+import { describe, expect, vi, test, beforeEach } from "vitest";
+import makeRemovePost from "./remove-post";
+import { makeFakeRawPost } from "../../__test__/fixtures/post.js";
+describe("Remove post use case", () => {
+  let postsDb;
+  let removePost;
+  beforeEach(() => {
+    let remove = vi.fn(async (id) => {
+      return { data: null, error: null };
+    });
+    postsDb = { remove };
+    removePost = makeRemovePost({ postsDb });
+  });
+  test("Removes post successfully", async () => {
+    let post = makeFakeRawPost();
+    let expected = post;
+    let actual = await removePost(post);
+    let postsDbRemoveArgs = postsDb.remove.mock.calls[0][0];
+    expect(actual).toEqual(expected);
+    expect(postsDb.remove).toBeCalledTimes(1);
+    expect(postsDbRemoveArgs).toEqual(post.id);
+  });
+  test("Throws error when database deletion fails", async () => {
+    let post = makeFakeRawPost({ id: null, createdAt: null });
+    let error = { message: "Post deletion error message" };
+    postsDb.remove.mockImplementation(async () => {
+      return { data: null, error };
+    });
+    expect(removePost(post)).rejects.toThrow(
+      `Error deleting post from database: ${error.message}. Post deletion failed.`
+    );
+  });
+});

--- a/backend/src/apps/posts/domain/use-cases/update-post.js
+++ b/backend/src/apps/posts/domain/use-cases/update-post.js
@@ -2,7 +2,7 @@ import makePost from "../entities/post/index.js";
 export default function makeUpdatePost({ postsDb }) {
   return async function updatePost(postDetails) {
     const post = makePost(postDetails);
-    let { data: updatedPostRecord, error } = await postsDb.update({
+    let { error } = await postsDb.update({
       id: post.getId(),
       userId: post.getUserId(),
       title: post.getTitle(),
@@ -17,4 +17,3 @@ export default function makeUpdatePost({ postsDb }) {
     return { ...post.getDTO() };
   };
 }
-//TODO: Add test

--- a/backend/src/apps/posts/entry-points/api/delete/delete-post.js
+++ b/backend/src/apps/posts/entry-points/api/delete/delete-post.js
@@ -1,0 +1,36 @@
+export default function makeDeletePost({ removePost }) {
+  return async function deletePost(httpRequest) {
+    try {
+      const user = httpRequest.user;
+      const post = httpRequest.body;
+      console.log(post);
+      if (user && user.userId === post.userId) {
+        const deleted = await removePost(post);
+        console.log(deleted, removePost);
+        return {
+          headers: {
+            "Content-Type": "application/json",
+          },
+          statusCode: 200,
+          body: { deleted },
+        };
+      }
+      return {
+        headers: {
+          "Content-Type": "application/json",
+        },
+        statusCode: 400,
+        body: { error: "Not authorized to perform this action." },
+      };
+    } catch (e) {
+      //TODO: Error logging
+      console.log(e);
+
+      return {
+        headers: { "Content-Type": "application/json" },
+        statusCode: 400,
+        body: { error: e.message },
+      };
+    }
+  };
+}

--- a/backend/src/apps/posts/entry-points/api/delete/delete-post.spec.js
+++ b/backend/src/apps/posts/entry-points/api/delete/delete-post.spec.js
@@ -1,0 +1,80 @@
+import { describe, expect, beforeEach, vi, test } from "vitest";
+import { makeFakeRawPost } from "../../../__test__/fixtures/post";
+import makeDeletePost from "./delete-post";
+
+describe("Controller for DELETE to /api/posts/:id endpoint", () => {
+  let removePost = vi.fn(async (post) => {
+    console.log("passed in", post);
+    return post;
+  });
+  let deletePost;
+
+  beforeEach(() => {
+    deletePost = makeDeletePost({ removePost });
+  });
+  test("Refuses to update a post without valid user credentials", async () => {
+    const post = makeFakeRawPost();
+    const request = {
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: { ...post },
+    };
+    const expected = {
+      headers: {
+        "Content-Type": "application/json",
+      },
+      statusCode: 400,
+      body: { error: "Not authorized to perform this action." },
+    };
+    const actual = await deletePost(request);
+    expect(actual).toEqual(expected);
+  });
+  test("Successfully deletes a post", async () => {
+    const post = makeFakeRawPost();
+    const user = { userId: post.userId };
+    const request = {
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: { ...post },
+      user,
+    };
+    const expected = {
+      headers: {
+        "Content-Type": "application/json",
+      },
+      statusCode: 200,
+      body: { deleted: post },
+    };
+    const actual = await deletePost(request);
+    expect(actual).toEqual(expected);
+  });
+
+  test("Returns expected response error when exception is thrown", async () => {
+    const error = {
+      message: "Error thrown by DELETE /api/posts/:id controller",
+    };
+    removePost.mockImplementation(async () => {
+      throw new Error(error.message);
+    });
+    const post = makeFakeRawPost();
+    const user = { userId: post.userId };
+    const request = {
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: { ...post },
+      user,
+    };
+    const expected = {
+      headers: {
+        "Content-Type": "application/json",
+      },
+      statusCode: 400,
+      body: { error: error.message },
+    };
+    const actual = await deletePost(request);
+    expect(actual).toEqual(expected);
+  });
+});

--- a/backend/src/apps/posts/entry-points/api/index.js
+++ b/backend/src/apps/posts/entry-points/api/index.js
@@ -3,6 +3,7 @@ import {
   getAllPosts,
   getSinglePost,
   patchPost,
+  deletePost,
 } from "./post-controller.js";
 import authMiddleware from "../../auth-middleware/index.js";
 import express from "express";
@@ -13,5 +14,6 @@ router.post("/", authMiddleware, makeCallback(postPost));
 router.get("/", makeCallback(getAllPosts));
 router.get("/:id", makeCallback(getSinglePost));
 router.patch("/:id", authMiddleware, makeCallback(patchPost));
+router.delete("/:id", authMiddleware, makeCallback(deletePost));
 
 export default router;

--- a/backend/src/apps/posts/entry-points/api/post-controller.js
+++ b/backend/src/apps/posts/entry-points/api/post-controller.js
@@ -3,23 +3,27 @@ import {
   retrievePosts,
   retrieveSinglePost,
   updatePost,
+  removePost,
 } from "../../domain/use-cases/index.js";
 import { handleAttachmentPreview } from "../../domain/use-cases/index.js";
 import makePostPost from "./post/post-post.js";
 import makeGetAllPosts from "./get/get-all-posts.js";
 import makeGetSinglePost from "./get/get-single-post.js";
 import makePatchPost from "./patch/patch-post.js";
+import makeDeletePost from "./delete/delete-post.js";
 
 const postPost = makePostPost({ createPost, handleAttachmentPreview });
 const getAllPosts = makeGetAllPosts({ retrievePosts });
 const getSinglePost = makeGetSinglePost({ retrieveSinglePost });
 const patchPost = makePatchPost({ updatePost, handleAttachmentPreview });
+const deletePost = makeDeletePost({ removePost });
 const postController = Object.freeze({
   postPost,
   getAllPosts,
   getSinglePost,
   patchPost,
+  deletePost,
 });
 
 export default postController;
-export { postPost, getAllPosts, getSinglePost, patchPost };
+export { postPost, getAllPosts, getSinglePost, patchPost, deletePost };


### PR DESCRIPTION
Allows deletion of posts via a /DELETE endpoint in the posts component on the backend. The URL for the endpoint would be "[backend URL]/api/posts/[post ID]".