### PR TITLE
Implement auth when deleting posts

### DIFF
--- a/backend/src/apps/posts/auth-middleware/index.js
+++ b/backend/src/apps/posts/auth-middleware/index.js
@@ -3,7 +3,6 @@ export default function (req, res, next) {
     req.user = req.session.user;
     next();
   } else {
-    console.log("not allowed");
     res.redirect(process.env.NOT_PERMITTED_REDIRECT);
   }
 }

--- a/backend/src/apps/posts/data-access/images-db.js
+++ b/backend/src/apps/posts/data-access/images-db.js
@@ -5,7 +5,6 @@ export default function buildMakeImagesDb({ dbClient, makeImage }) {
   });
 
   async function insert({ extension, imageData }) {
-    console.log("EXT", extension, imageData);
     return await dbClient.storage
       .from("images")
       .upload(extension, imageData, { contentType: "image/png", upsert: true }); //TODO: Add .env for "images", make contentType dynamic?

--- a/backend/src/apps/posts/data-access/posts-db.js
+++ b/backend/src/apps/posts/data-access/posts-db.js
@@ -51,9 +51,12 @@ export default function makePostsDb({ dbClient }) {
       .eq("id", updateDetails.id);
     return { ...result };
   }
-  async function remove(postId) {
-    let result = await dbClient.from("posts").delete().eq("id", postId);
-    console.log(result);
+  async function remove(postId, userId) {
+    let result = await dbClient
+      .from("posts")
+      .delete()
+      .eq("id", postId)
+      .eq("userId", userId);
     return { ...result };
   }
   async function insert(insertDetails) {

--- a/backend/src/apps/posts/domain/use-cases/remove-post.js
+++ b/backend/src/apps/posts/domain/use-cases/remove-post.js
@@ -2,7 +2,7 @@ import makePost from "../entities/post/index.js";
 export default function makeRemovePost({ postsDb }) {
   return async function removePost(postDetails) {
     const post = makePost(postDetails);
-    let { error } = await postsDb.remove(post.getId());
+    let { error } = await postsDb.remove(post.getId(), post.getUserId());
     if (error) {
       throw new Error(
         `Error deleting post from database: ${error.message}. Post deletion failed.`

--- a/backend/src/apps/posts/entry-points/api/delete/delete-post.js
+++ b/backend/src/apps/posts/entry-points/api/delete/delete-post.js
@@ -1,12 +1,11 @@
-export default function makeDeletePost({ removePost }) {
+export default function makeDeletePost({ retrieveSinglePost, removePost }) {
   return async function deletePost(httpRequest) {
     try {
       const user = httpRequest.user;
-      const post = httpRequest.body;
-      console.log(post);
+      const { id: postId } = httpRequest.params;
+      const post = await retrieveSinglePost(postId);
       if (user && user.userId === post.userId) {
         const deleted = await removePost(post);
-        console.log(deleted, removePost);
         return {
           headers: {
             "Content-Type": "application/json",

--- a/backend/src/apps/posts/entry-points/api/delete/delete-post.spec.js
+++ b/backend/src/apps/posts/entry-points/api/delete/delete-post.spec.js
@@ -4,7 +4,6 @@ import makeDeletePost from "./delete-post";
 
 describe("Controller for DELETE to /api/posts/:id endpoint", () => {
   let removePost = vi.fn(async (post) => {
-    console.log("passed in", post);
     return post;
   });
   let deletePost;

--- a/backend/src/apps/posts/entry-points/api/post-controller.js
+++ b/backend/src/apps/posts/entry-points/api/post-controller.js
@@ -16,7 +16,7 @@ const postPost = makePostPost({ createPost, handleAttachmentPreview });
 const getAllPosts = makeGetAllPosts({ retrievePosts });
 const getSinglePost = makeGetSinglePost({ retrieveSinglePost });
 const patchPost = makePatchPost({ updatePost, handleAttachmentPreview });
-const deletePost = makeDeletePost({ removePost });
+const deletePost = makeDeletePost({ retrieveSinglePost, removePost });
 const postController = Object.freeze({
   postPost,
   getAllPosts,

--- a/src/services.js
+++ b/src/services.js
@@ -76,7 +76,7 @@ const upvotePost = async (postId, userId) => {
 };
 const checkHasUpvoted = async (postId, userId) => {
   let { data: hasUpvoted } = await axios.post(
-    `http://localhost:3000/post/hasUpvoted/${postId}`,
+    `http://localhost:3000/post/hasUpvoted/${id}`,
     userId,
     {
       headers: {
@@ -87,13 +87,16 @@ const checkHasUpvoted = async (postId, userId) => {
   return hasUpvoted;
 };
 const deletePost = async (postId) => {
-  if (postId) {
+  try {
     let { data: deletedPost } = await axios.delete(
-      `http://localhost:3000/post/${postId}`
+      `http://localhost:3000/api/posts/${postId}`
     );
     return deletedPost;
-  } else {
-    return null;
+  } catch (e) {
+    console.log(e);
+    let { data, status, statusText } = e.response;
+    let errorMsg = data.error;
+    return { error: errorMsg || statusText, status };
   }
 };
 export {


### PR DESCRIPTION
Previously, the delete-post controller would only check if the user was logged in, and not if the logged-in user was the user authorized to delete the post in question. Although the frontend already has safeguards in this matter, this PR further hardens security by ensuring an error is returned immediately if the post is found to have a different author than the one sending the DELETE request.