### PR TITLE
Set up SSL on backend server

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - web-root:/var/www/html
     depends_on:
       - nginx
-    command: certonly --webroot --webroot-path=/var/www/html --email kmaryam818@gmail.com --agree-tos --no-eff-email --staging -d cv-circle.com  -d www.cv-circle.com
+    command: certonly --webroot --webroot-path=/var/www/html --email kmaryam818@gmail.com --agree-tos --no-eff-email --force-renewal -d cv-circle.com  -d www.cv-circle.com
 
   zookeeper:
     image: confluentinc/cp-zookeeper:latest

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   nginx:
     image: nginx:stable-alpine
     volumes:
-      - ${PWD}/nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
       - certbot-etc:/etc/letsencrypt
       - certbot-var:/var/lib/letsencrypt
       - web-root:/var/www/html

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -174,5 +174,5 @@ volumes:
     driver: local
     driver_opts:
       type: none
-      device: /home/cv-circle-admin/cv-circle/frontend/
+      device: $FRONTEND_DIR
       o: bind

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   nginx:
     image: nginx:stable-alpine
     volumes:
-      - ./nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
+      - ${PWD}/nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
       - certbot-etc:/etc/letsencrypt
       - certbot-var:/var/lib/letsencrypt
       - web-root:/var/www/html

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   nginx:
     image: nginx:stable-alpine
     volumes:
-      - $PWD/nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
       - certbot-etc:/etc/letsencrypt
       - certbot-var:/var/lib/letsencrypt
       - web-root:/var/www/html

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -179,8 +179,8 @@ volumes:
       device: $FRONTEND_DIR
       o: bind
   dhparam:
-  driver: local
-  driver_opts:
-    type: none
-    device: $PWD/dhparam/
-    o: bind
+    driver: local
+    driver_opts:
+      type: none
+      device: $BACKEND_DIR/dhparam/
+      o: bind

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -7,8 +7,10 @@ services:
       - certbot-etc:/etc/letsencrypt
       - certbot-var:/var/lib/letsencrypt
       - web-root:/var/www/html
+      - dhparam:/etc/ssl/certs
     ports:
       - "80:80"
+      - "443:443"
     depends_on:
       - users
       - posts
@@ -176,3 +178,9 @@ volumes:
       type: none
       device: $FRONTEND_DIR
       o: bind
+  dhparam:
+  driver: local
+  driver_opts:
+    type: none
+    device: $PWD/dhparam/
+    o: bind

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -4,11 +4,25 @@ services:
     image: nginx:stable-alpine
     volumes:
       - $PWD/nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
+      - certbot-etc:/etc/letsencrypt
+      - certbot-var:/var/lib/letsencrypt
+      - web-root:/var/www/html
     ports:
       - "80:80"
     depends_on:
       - users
       - posts
+
+  certbot:
+    image: certbot/certbot
+    container_name: certbot
+    volumes:
+      - certbot-etc:/etc/letsencrypt
+      - certbot-var:/var/lib/letsencrypt
+      - web-root:/var/www/html
+    depends_on:
+      - nginx
+    command: certonly --webroot --webroot-path=/var/www/html --email kmaryam818@gmail.com --agree-tos --no-eff-email --staging -d cv-circle.com  -d www.cv-circle.com
 
   zookeeper:
     image: confluentinc/cp-zookeeper:latest
@@ -154,3 +168,11 @@ volumes:
     external: true
   kafka:
     external: true
+  certbot-etc:
+  certbot-var:
+  web-root:
+    driver: local
+    driver_opts:
+      type: none
+      device: /home/cv-circle-admin/cv-circle/frontend/
+      o: bind

--- a/backend/nginx/default.conf
+++ b/backend/nginx/default.conf
@@ -1,7 +1,7 @@
 server {
     listen 80;
     listen [::]:80 default_server;
-    server_name cv-circle.com www.cv-circle.com
+    server_name cv-circle.com www.cv-circle.com;
 
     location /.well-known/acme-challenge/ {
         root /home/cv-circle-admin/cv-circle/frontend/; # Replace with the path to your webroot directory

--- a/backend/nginx/default.conf
+++ b/backend/nginx/default.conf
@@ -4,9 +4,10 @@ server {
     server_name cv-circle.com www.cv-circle.com;
 
     location /.well-known/acme-challenge/ {
-        root /home/cv-circle-admin/cv-circle/frontend/; # Replace with the path to your webroot directory
+        root /var/www/html/; # Replace with the path to your webroot directory
         default_type text/plain;
     }
+    
     location /api/posts/ {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/backend/nginx/default.conf
+++ b/backend/nginx/default.conf
@@ -1,6 +1,7 @@
 server {
     listen 80;
     listen [::]:80 default_server;
+    server_name cv-circle.com www.cv-circle.com
     location /api/posts/ {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/backend/nginx/default.conf
+++ b/backend/nginx/default.conf
@@ -2,6 +2,11 @@ server {
     listen 80;
     listen [::]:80 default_server;
     server_name cv-circle.com www.cv-circle.com
+
+    location /.well-known/acme-challenge/ {
+        root /home/cv-circle-admin/cv-circle/frontend/; # Replace with the path to your webroot directory
+        default_type text/plain;
+    }
     location /api/posts/ {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/backend/nginx/default.conf
+++ b/backend/nginx/default.conf
@@ -39,6 +39,14 @@ server {
         resolver 8.8.8.8;
 
         location /api/posts/ {
+            try_files $uri @posts;
+        }
+
+        location /api/auth/ {
+            try_files $uri @auth;
+        }
+
+        location @posts {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header Host $http_host;
@@ -54,7 +62,7 @@ server {
             # enable strict transport security only if you understand the implications
         }
 
-        location /api/auth/ {
+        location @auth {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header Host $http_host;

--- a/backend/nginx/default.conf
+++ b/backend/nginx/default.conf
@@ -7,22 +7,66 @@ server {
         root /var/www/html/; # Replace with the path to your webroot directory
         default_type text/plain;
     }
-    
-    location /api/posts/ {
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header Host $http_host;
-        proxy_set_header X-NginX-Proxy true;
-        proxy_redirect off;
-        proxy_pass http://posts:3000/;
+    location / {
+            rewrite ^ https://$host$request_uri? permanent;
     }
+}
 
-    location /api/auth/ {
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header Host $http_host;
-        proxy_set_header X-NginX-Proxy true;
-        proxy_redirect off;
-        proxy_pass http://users:3001/;
-    }
+server {
+        listen 443 ssl http2;
+        listen [::]:443 ssl http2;
+        server_name cv-circle.com www.cv-circle.com;
+
+        server_tokens off;
+
+        ssl_certificate /etc/letsencrypt/live/cv-circle.com/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/cv-circle.com/privkey.pem;
+
+        ssl_buffer_size 8k;
+
+        ssl_dhparam /etc/ssl/certs/dhparam-2048.pem;
+
+        ssl_protocols TLSv1.2;
+        ssl_prefer_server_ciphers on;
+
+        ssl_ciphers ECDH+AESGCM:ECDH+AES256:ECDH+AES128:DH+3DES:!ADH:!AECDH:!MD5;
+
+        ssl_ecdh_curve secp384r1;
+        ssl_session_tickets off;
+
+        ssl_stapling on;
+        ssl_stapling_verify on;
+        resolver 8.8.8.8;
+
+        location /api/posts/ {
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-NginX-Proxy true;
+            proxy_redirect off;
+            proxy_pass http://posts:3000/;
+            add_header X-Frame-Options "SAMEORIGIN" always;
+            add_header X-XSS-Protection "1; mode=block" always;
+            add_header X-Content-Type-Options "nosniff" always;
+            add_header Referrer-Policy "no-referrer-when-downgrade" always;
+            add_header Content-Security-Policy "default-src * data: 'unsafe-eval' 'unsafe-inline'" always;
+            #add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+            # enable strict transport security only if you understand the implications
+        }
+
+        location /api/auth/ {
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-NginX-Proxy true;
+            proxy_redirect off;
+            proxy_pass http://users:3001/;
+            add_header X-Frame-Options "SAMEORIGIN" always;
+            add_header X-XSS-Protection "1; mode=block" always;
+            add_header X-Content-Type-Options "nosniff" always;
+            add_header Referrer-Policy "no-referrer-when-downgrade" always;
+            add_header Content-Security-Policy "default-src * data: 'unsafe-eval' 'unsafe-inline'" always;
+            #add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+            # enable strict transport security only if you understand the implications
+        }
 }

--- a/backend/nginx/default.conf
+++ b/backend/nginx/default.conf
@@ -39,14 +39,6 @@ server {
         resolver 8.8.8.8;
 
         location /api/posts/ {
-            try_files $uri @posts;
-        }
-
-        location /api/auth/ {
-            try_files $uri @auth;
-        }
-
-        location @posts {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header Host $http_host;
@@ -62,7 +54,7 @@ server {
             # enable strict transport security only if you understand the implications
         }
 
-        location @auth {
+        location /api/auth/ {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header Host $http_host;

--- a/backend/src/apps/posts/entry-points/server.js
+++ b/backend/src/apps/posts/entry-points/server.js
@@ -21,7 +21,7 @@ app.use(
 app.use(expressFileUpload());
 app.use(
   cors({
-    origin: "http://localhost:5173",
+    origin: "https://cv-circle.onrender.com",
     methods: "GET,POST,PUT,DELETE,PATCH",
     credentials: true,
   })

--- a/backend/src/apps/posts/entry-points/server.js
+++ b/backend/src/apps/posts/entry-points/server.js
@@ -8,12 +8,14 @@ import { sessionDetailsConsumer } from "./message-queue/index.js";
 import { cacheStore } from "../data-access/index.js";
 
 const app = express();
+app.enable("trust proxy");
 app.use(express.json());
 app.use(
   session({
     store: cacheStore,
     secret: process.env.SESSION_SECRET,
     resave: false,
+    proxy: true,
     saveUninitialized: false,
   })
 );

--- a/backend/src/apps/users/entry-points/server.js
+++ b/backend/src/apps/users/entry-points/server.js
@@ -9,13 +9,14 @@ import configuredPassportInstance from "../authentication/passport-setup/index.j
 let redisStore = new RedisStore({ client: redisClient, prefix: "sess:" });
 
 const app = express();
-
+app.enable("trust proxy");
 app.use(express.json());
 app.use(
   session({
     store: redisStore,
     secret: process.env.SESSION_SECRET,
     resave: false,
+    proxy: true,
     cookie: { maxAge: 86400000 },
     saveUninitialized: false,
   })

--- a/backend/src/apps/users/entry-points/server.js
+++ b/backend/src/apps/users/entry-points/server.js
@@ -22,7 +22,7 @@ app.use(
 );
 app.use(
   cors({
-    origin: "http://localhost:5173",
+    origin: "https://cv-circle.onrender.com",
     methods: "GET,POST,PUT,DELETE,PATCH",
     credentials: true,
   })


### PR DESCRIPTION
This PR allows the server to receive HTTPS requests by setting up SSL certificates. Certbot is used to generate certificates and OpenSSL is used to generate the server's private key. Additionally, the Express servers running the posts and users components have been configured to trust the proxy information. 