### PR TITLE
Fix bug with auth redirect

### DIFF
--- a/backend/src/apps/users/authentication/authentication-strategies/github-strategy.js
+++ b/backend/src/apps/users/authentication/authentication-strategies/github-strategy.js
@@ -6,7 +6,7 @@ export default function buildGithubStrategy({
     {
       clientID: process.env.GITHUB_CLIENT_ID,
       clientSecret: process.env.GITHUB_CLIENT_SECRET,
-      callbackURL: `/api/auth${process.env.GITHUB_CALLBACK_URL}`,
+      callbackURL: `https://cv-circle.com/api/auth${process.env.GITHUB_CALLBACK_URL}`,
     },
     verificationCallback
   );

--- a/backend/src/apps/users/authentication/authentication-strategies/google-strategy.js
+++ b/backend/src/apps/users/authentication/authentication-strategies/google-strategy.js
@@ -6,7 +6,7 @@ export default function buildGoogleStrategy({
     {
       clientID: process.env.GOOGLE_CLIENT_ID,
       clientSecret: process.env.GOOGLE_CLIENT_SECRET,
-      callbackURL: `/api/auth${process.env.GOOGLE_CALLBACK_URL}`,
+      callbackURL: `https://cv-circle.com/api/auth${process.env.GOOGLE_CALLBACK_URL}`,
     },
     verificationCallback
   );


### PR DESCRIPTION
Previously the Passport authorization strategies were redirecting to "http://cv-circle.com/...". This PR specifies HTTPS in the callback URLs used by the authorization strategies.