### PR TITLE
Fixed whitespace issue in post form

### DIFF
--- a/frontend/src/components/PostForm.jsx
+++ b/frontend/src/components/PostForm.jsx
@@ -149,11 +149,11 @@ const PostForm = () => {
           <textarea
             id="post-content"
             name="post-content"
-            rows="4"
+            rows="10"
             cols="50"
             value={post.postContent}
             onChange={(e) => setPost({ ...post, postContent: e.target.value })}
-            className="border border-slate-800 w-full p-2 rounded"
+            className="border border-slate-800 w-full p-2 rounded whitespace-pre-wrap"
           ></textarea>
         </span>
         <span className="flex flex-col md:flex-row justify-center items-center">

--- a/frontend/src/components/ReplyForm.jsx
+++ b/frontend/src/components/ReplyForm.jsx
@@ -74,7 +74,7 @@ const ReplyForm = ({ mode, setReplyFormActive, original }) => {
           cols="50"
           value={post.postContent}
           onChange={(e) => setPost({ ...post, postContent: e.target.value })}
-          className="border border-slate-800 w-full p-2 rounded"
+          className="border border-slate-800 w-full p-2 rounded whitespace-pre-wrap"
         ></textarea>
         <span className="flex flex-row md:flex-col justify-center gap-3 m-3">
           <button


### PR DESCRIPTION
Earlier, the textboxes that would hold a post's content were not preserving line breaks and whitespace. This patch fixes that issue.