### PR TITLE
Fix newlines' display in post content paragraph elements

### DIFF
--- a/frontend/dist/output.css
+++ b/frontend/dist/output.css
@@ -529,22 +529,6 @@ h1,
   --tw-backdrop-sepia:  ;
 }
 
-.visible {
-  visibility: visible;
-}
-
-.static {
-  position: static;
-}
-
-.absolute {
-  position: absolute;
-}
-
-.relative {
-  position: relative;
-}
-
 .m-2 {
   margin: 0.5rem;
 }
@@ -736,14 +720,6 @@ h1,
   animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
 }
 
-.cursor-pointer {
-  cursor: pointer;
-}
-
-.resize {
-  resize: both;
-}
-
 .flex-row {
   flex-direction: row;
 }
@@ -762,10 +738,6 @@ h1,
 
 .items-stretch {
   align-items: stretch;
-}
-
-.justify-end {
-  justify-content: flex-end;
 }
 
 .justify-center {
@@ -809,6 +781,10 @@ h1,
 .hyphens-auto {
   -webkit-hyphens: auto;
           hyphens: auto;
+}
+
+.whitespace-pre-wrap {
+  white-space: pre-wrap;
 }
 
 .break-words {
@@ -898,11 +874,6 @@ h1,
 
 .bg-slate-100\/50 {
   background-color: rgb(241 245 249 / 0.5);
-}
-
-.bg-slate-300 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(203 213 225 / var(--tw-bg-opacity));
 }
 
 .bg-slate-50\/80 {
@@ -1136,21 +1107,8 @@ h1,
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
-.blur {
-  --tw-blur: blur(8px);
-  filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
-}
-
 .filter {
   filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
-}
-
-.transition {
-  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, -webkit-backdrop-filter;
-  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;
-  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter, -webkit-backdrop-filter;
-  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-  transition-duration: 150ms;
 }
 
 html,

--- a/frontend/src/components/Reply.jsx
+++ b/frontend/src/components/Reply.jsx
@@ -35,7 +35,9 @@ const Reply = ({ reply: reply }) => {
             replyFormActive && mode === "edit" && "hidden"
           } w-full`}
         >
-          {reply.postContent}
+          <p className="flex-1 break-words whitespace-pre-wrap pr-5" lang="en">
+            {reply.postContent}
+          </p>
           {replyFormActive && mode === "create" && (
             <ReplyForm
               setReplyFormActive={setReplyFormActive}

--- a/frontend/src/components/SinglePost.jsx
+++ b/frontend/src/components/SinglePost.jsx
@@ -58,13 +58,11 @@ const SinglePost = () => {
                   {post.title}
                 </h1>
               </span>
-
               <span className="flex flex-col pt-3 md:pt-0 md:flex-row gap-3 justify-between">
                 <p
-                  className="text-lg flex-1 break-words hyphens-auto pr-5"
+                  className="text-lg flex-1 break-words whitespace-pre-wrap pr-5"
                   lang="en"
                 >
-                  {" "}
                   {post.postContent}
                 </p>
 


### PR DESCRIPTION
This is a follow-up to the previous PR. Now that the form submission preserves the newlines, the paragraph elements need to render the newlines. This PR adds the necessary TailwindCSS properties to achieve this goal.