### PR TITLE
Show all replies in reply list

### DIFF
--- a/frontend/src/components/ReplyList.jsx
+++ b/frontend/src/components/ReplyList.jsx
@@ -13,7 +13,7 @@ const ReplyList = ({ replies }) => {
             {" "}
             Insights{" "}
           </h3>
-          {replies.map(([reply]) => (
+          {replies[0].map((reply) => (
             <Reply reply={reply} key={reply.id} />
           ))}
         </div>


### PR DESCRIPTION
Previously, the ReplyList component only displayed one reply even if many were stored in the database. This PR fixes that issue by traversing the nested array within each post's "replies" attribute, rather than the outer array. 