### PR TITLE
Fetch new image when post is edited 

### DIFF
--- a/frontend/src/components/PostForm.jsx
+++ b/frontend/src/components/PostForm.jsx
@@ -26,9 +26,11 @@ const PostForm = () => {
     let { file } = post;
     if (!file) {
       let result = await updatePost({ ...post, id: toEditId }, toEditId); //TODO: set status
+      navigate(`/post/${toEditId}`);
       console.log(result);
     } else if (checkFileConstraints(file)) {
       let result = await updatePost({ ...post, id: toEditId }, toEditId); //TODO: set status
+      navigate(`/post/${toEditId}/updated`);
     } else {
       setStatus({
         error: true,
@@ -36,8 +38,6 @@ const PostForm = () => {
         success: null,
       });
     }
-
-    navigate(`/post/${toEditId}`);
   };
 
   const uploadNewPost = async (e) => {

--- a/frontend/src/components/SinglePost.jsx
+++ b/frontend/src/components/SinglePost.jsx
@@ -10,7 +10,7 @@ import ReplyForm from "./ReplyForm";
 
 const SinglePost = () => {
   const { user } = useContext(UserContext);
-  const { id: postId } = useParams();
+  const { id: postId, updated } = useParams();
   const navigate = useNavigate();
   const [postLoaded, setPostLoaded] = useState(false);
   const [post, setPost] = useState({});
@@ -68,7 +68,11 @@ const SinglePost = () => {
 
                 <span className="flex flex-col pl-5 md:w-[25%] justify-center self-center">
                   <Link
-                    to={post.imgCdn}
+                    to={
+                      updated === true
+                        ? post.imgCdn + "?t=" + Date.now()
+                        : post.imgCdn
+                    }
                     className="hover:cursor-pointer w-full flex justify-center md:justify-end"
                     target="_blank"
                     aria-label="View image in full size"

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -26,7 +26,7 @@ ReactDOM.createRoot(document.getElementById("root")).render(
           <Route path="/logged-in" element={<LoggedIn />} />
           <Route path="/logged-out" element={<LoggedOut />} />
           <Route path="/create-post" element={<PostForm />} />
-          <Route path="/post/:id" element={<SinglePost />} />
+          <Route path="/post/:id/:updated?" element={<SinglePost />} />
           <Route path="/edit-post/:id" element={<PostForm />} />
           <Route path="/not-permitted" element={<NotPermitted />} />
           <Route path="/post-skeleton" element={<PostSkeleton />} />


### PR DESCRIPTION
Previously, the SinglePost component would render the cached version of the post's image even when the post was edited. This patch temporarily fixes that issue by directing posts to the post URL with the route parameter 'updated'. This causes the SinglePost component to grab the image with a new timestamp appended to the end of the image CDN's URL. 

The complete fix, which will be delivered soon, involves having a "last modified" attribute on each post so that the CDN can be updated automatically.