### PR TITLE
Made image cache solution more concise

### DIFF
--- a/frontend/src/components/SinglePost.jsx
+++ b/frontend/src/components/SinglePost.jsx
@@ -69,9 +69,7 @@ const SinglePost = () => {
                 <span className="flex flex-col pl-5 md:w-[25%] justify-center self-center">
                   <Link
                     to={
-                      updated === true
-                        ? post.imgCdn + "?t=" + Date.now()
-                        : post.imgCdn
+                      updated ? post.imgCdn + "?t=" + Date.now() : post.imgCdn
                     }
                     className="hover:cursor-pointer w-full flex justify-center md:justify-end"
                     target="_blank"


### PR DESCRIPTION
This update makes the image cache bug's solution more concise. Previously, the conditional in SinglePost required the 'updated' route parameter to equal 'true', but that can be simplified even further by removing the comparison.