### PR TITLE
Fix typo causing post ID duplication in downvoted or upvoted lists

### DIFF
--- a/frontend/src/hooks/useVotedPosts.js
+++ b/frontend/src/hooks/useVotedPosts.js
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 
 function getRecordOrDefault(voteType) {
   const stored = sessionStorage.getItem(voteType);
@@ -12,8 +12,9 @@ export function useVotedPosts(voteType) {
   const [votes, setVotes] = useState(getRecordOrDefault(voteType));
 
   const setVotesRecord = (posts) => {
-    setVotes((prevPosts) => new Set(posts));
-    sessionStorage.setItem(voteType, JSON.stringify([...posts.values()]));
+    let newPosts = new Set(posts);
+    setVotes((prevPosts) => newPosts);
+    sessionStorage.setItem(voteType, JSON.stringify([...newPosts.values()]));
   };
 
   return [votes, setVotesRecord];


### PR DESCRIPTION
Previously, there was a bug causing post IDs to temporarily duplicate in sessionStorage. This is because the useVotedPosts hook's setVotesRecord function was setting the upvoted/downvoted sessionStorage value to its argument as a JSON string.
 
This PR fixes that issue by setting those values to a Set of the argument as a JSON string. This same Set is used to update the "votes" state variable.