### PR TITLE
Constrain filesize in post creation and editing 

### DIFF
--- a/backend/src/apps/posts/package.json
+++ b/backend/src/apps/posts/package.json
@@ -23,7 +23,8 @@
     "kafkajs": "2.2.4",
     "@kafkajs/confluent-schema-registry": "3.3.0",
     "redis": "4.6.7",
-    "connect-redis": "7.1.0"
+    "connect-redis": "7.1.0",
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
     "@faker-js/faker": "^8.0.2",
@@ -32,7 +33,6 @@
     "@vitest/ui": "^0.32.2",
     "@web-std/file": "^3.0.2",
     "supertest": "^6.3.3",
-    "vitest": "^0.32.0",
-    "lodash": "^4.17.21"
+    "vitest": "^0.32.0"
   }
 }

--- a/frontend/src/components/PostForm.jsx
+++ b/frontend/src/components/PostForm.jsx
@@ -51,7 +51,7 @@ const PostForm = () => {
     } else {
       setStatus({
         error: true,
-        msg: "Error: Please only attach .pdf, .png, .jpg, or .jpeg files.",
+        msg: "Error: Please only attach .pdf, .png, .jpg, or .jpeg files, and ensure your file is smaller than 1MB.",
         success: 0,
       });
     }
@@ -86,7 +86,7 @@ const PostForm = () => {
     } else {
       setStatus({
         error: true,
-        msg: "Error: Please only attach .pdf, .png, .jpg, or .jpeg files.",
+        msg: "Error: Please only attach .pdf, .png, .jpg, or .jpeg files, and ensure your file is smaller than 1MB.",
         success: 0,
       });
     }
@@ -107,10 +107,12 @@ const PostForm = () => {
 
   const checkFileConstraints = (file) => {
     return (
-      file.type == "image/png" ||
-      file.type == "image/jpg" ||
-      file.type == "image/jpeg" ||
-      file.type == "application/pdf" //TODO: change to constants
+      file.size < 1000000 &&
+      (file.type == "image/png" ||
+        file.type == "image/jpg" ||
+        file.type == "image/jpeg" ||
+        file.type == "application/pdf")
+      //TODO: change to constants
     );
   };
 


### PR DESCRIPTION
To match the maximum entity size, this PR would:

Limit post attachment size to 1MB
Catch error if file size exceeded before the request is made to the server