### PR TITLE
Optimize auth-middleware in posts feature

### DIFF
--- a/backend/src/apps/posts/auth-middleware/index.js
+++ b/backend/src/apps/posts/auth-middleware/index.js
@@ -1,7 +1,9 @@
 export default function (sameUserNecessary = false) {
   return function (req, res, next) {
     req.user = req.session?.user;
-    req.isAuthenticated = () => (req.user ? true : false);
+    if (!req.hasOwnProperty("isAuthenticated")) {
+      req.isAuthenticated = () => (req.user ? true : false);
+    }
     if (!req.isAuthenticated()) {
       console.log("no user");
       res.status(403).send({ error: "Unauthorized" });

--- a/backend/src/apps/posts/auth-middleware/index.js
+++ b/backend/src/apps/posts/auth-middleware/index.js
@@ -1,8 +1,18 @@
-export default function (req, res, next) {
-  if (req.session && req.session.user) {
-    req.user = req.session.user;
-    next();
-  } else {
-    res.redirect(process.env.NOT_PERMITTED_REDIRECT);
+export default function (sameUserNecessary = false) {
+  return function (req, res, next) {
+    req.user = req.session?.user;
+    req.isAuthenticated = () => (req.user ? true : false);
+    if (!req.isAuthenticated()) {
+      console.log("no user");
+      res.status(403).send({ error: "Unauthorized" });
+    } else if (sameUserNecessary && !isSameUser(req)) {
+      console.log("must be same");
+      res.status(403).send({ error: "Unauthorized" });
+    } else {
+      next();
+    }
+  };
+  function isSameUser(req) {
+    return req.body?.userId && req.user.userId === req.body.userId;
   }
 }

--- a/backend/src/apps/posts/data-access/posts-db.js
+++ b/backend/src/apps/posts/data-access/posts-db.js
@@ -99,8 +99,12 @@ export default function makePostsDb({ dbClient }) {
       .from("posts")
       .delete()
       .eq("id", postId)
-      .eq("fk_uid", userId);
-    return { ...result };
+      .eq("fk_uid", userId)
+      .select();
+    return {
+      ...result,
+      data: format(result.data, dbColumnsToNormalizedProfile),
+    };
   }
   async function insert(insertDetails) {
     let result = await dbClient

--- a/backend/src/apps/posts/domain/use-cases/handle-attachment-preview.spec.js
+++ b/backend/src/apps/posts/domain/use-cases/handle-attachment-preview.spec.js
@@ -52,7 +52,7 @@ describe("Create attachment preview use case", () => {
   });
 
   test("Successfully creates attachment preview for non-pdf files", async () => {
-    let file = { mimetype: "image/png", data: previewImage.getImageData() };
+    let file = { type: "image/png", data: previewImage.getImageData() };
     let result = await handleAttachmentPreview({ file, userId: FAKE_USER_ID });
 
     let makeImageArgs = makeImage.mock.calls[0][0];

--- a/backend/src/apps/posts/domain/use-cases/remove-post.js
+++ b/backend/src/apps/posts/domain/use-cases/remove-post.js
@@ -1,13 +1,18 @@
 import makePost from "../entities/post/index.js";
 export default function makeRemovePost({ postsDb }) {
-  return async function removePost(postDetails) {
-    const post = makePost(postDetails);
-    let { error } = await postsDb.remove(post.getId(), post.getUserId());
+  return async function removePost(postId, userId) {
+    let { data, error } = await postsDb.remove(postId, userId);
     if (error) {
       throw new Error(
         `Error deleting post from database: ${error.message}. Post deletion failed.`
       );
     }
+    if (!data) {
+      throw new Error(
+        `Error deleting post from database: either the post does not exist, or it does not belong to the user.`
+      );
+    }
+    let post = makePost(...data);
     return { ...post.getDTO() };
   };
 }

--- a/backend/src/apps/posts/entry-points/api/delete/delete-post.js
+++ b/backend/src/apps/posts/entry-points/api/delete/delete-post.js
@@ -18,8 +18,8 @@ export default function makeDeletePost({ retrieveSinglePost, removePost }) {
         headers: {
           "Content-Type": "application/json",
         },
-        statusCode: 400,
-        body: { error: "Not authorized to perform this action." },
+        statusCode: 403,
+        body: { error: "Unauthorized" },
       };
     } catch (e) {
       //TODO: Error logging

--- a/backend/src/apps/posts/entry-points/api/delete/delete-post.js
+++ b/backend/src/apps/posts/entry-points/api/delete/delete-post.js
@@ -1,25 +1,15 @@
-export default function makeDeletePost({ retrieveSinglePost, removePost }) {
+export default function makeDeletePost({ removePost }) {
   return async function deletePost(httpRequest) {
     try {
       const user = httpRequest.user;
       const { id: postId } = httpRequest.params;
-      const post = await retrieveSinglePost(postId, false);
-      if (user && user.userId === post.userId) {
-        const deleted = await removePost(post);
-        return {
-          headers: {
-            "Content-Type": "application/json",
-          },
-          statusCode: 200,
-          body: { deleted },
-        };
-      }
+      const deleted = await removePost(postId, user.userId || -1);
       return {
         headers: {
           "Content-Type": "application/json",
         },
-        statusCode: 403,
-        body: { error: "Unauthorized" },
+        statusCode: 200,
+        body: { deleted },
       };
     } catch (e) {
       //TODO: Error logging

--- a/backend/src/apps/posts/entry-points/api/delete/delete-post.spec.js
+++ b/backend/src/apps/posts/entry-points/api/delete/delete-post.spec.js
@@ -27,8 +27,8 @@ describe("Controller for DELETE to /api/posts/:id endpoint", () => {
       headers: {
         "Content-Type": "application/json",
       },
-      statusCode: 400,
-      body: { error: "Not authorized to perform this action." },
+      statusCode: 403,
+      body: { error: "Unauthorized" },
     };
     const actual = await deletePost(request);
     expect(actual).toEqual(expected);

--- a/backend/src/apps/posts/entry-points/api/index.js
+++ b/backend/src/apps/posts/entry-points/api/index.js
@@ -11,11 +11,11 @@ import express from "express";
 import makeCallback from "../../express-callback/index.js";
 const router = express.Router();
 
-router.post("/", authMiddleware, makeCallback(postPost));
+router.post("/", authMiddleware(), makeCallback(postPost));
 router.get("/", makeCallback(getAllPosts));
 router.get("/:id", makeCallback(getSinglePost));
-router.patch("/:id", authMiddleware, makeCallback(patchPost));
-router.delete("/:id", authMiddleware, makeCallback(deletePost));
-router.post("/vote", authMiddleware, makeCallback(postVote));
+router.patch("/:id", authMiddleware(true), makeCallback(patchPost));
+router.delete("/:id", authMiddleware(), makeCallback(deletePost));
+router.post("/vote", authMiddleware(), makeCallback(postVote));
 
 export default router;

--- a/backend/src/apps/posts/entry-points/api/patch/patch-post.js
+++ b/backend/src/apps/posts/entry-points/api/patch/patch-post.js
@@ -1,7 +1,6 @@
 export default function makePatchPost({ updatePost, handleAttachmentPreview }) {
   return async function patchPost(httpRequest) {
     try {
-      const user = httpRequest.user;
       const post = httpRequest.body;
       let extension = post.imgCdn.split(process.env.DB_BASE_CDN_URL).pop();
       if (post.file) {

--- a/backend/src/apps/posts/entry-points/api/patch/patch-post.js
+++ b/backend/src/apps/posts/entry-points/api/patch/patch-post.js
@@ -3,28 +3,19 @@ export default function makePatchPost({ updatePost, handleAttachmentPreview }) {
     try {
       const user = httpRequest.user;
       const post = httpRequest.body;
-      if (user && user.userId === post.userId) {
-        let extension = post.imgCdn.split(process.env.DB_BASE_CDN_URL).pop();
-        if (post.file) {
-          await handleAttachmentPreview({ ...post, ...{ extension } });
-        }
-        const toUpdate = post;
-        const updated = await updatePost(toUpdate);
-        return {
-          headers: {
-            "Content-Type": "application/json",
-            "Last-Modified": new Date(updated.modifiedOn).toUTCString(),
-          },
-          statusCode: 200,
-          body: { updated },
-        };
+      let extension = post.imgCdn.split(process.env.DB_BASE_CDN_URL).pop();
+      if (post.file) {
+        await handleAttachmentPreview({ ...post, ...{ extension } });
       }
+      const toUpdate = post;
+      const updated = await updatePost(toUpdate);
       return {
         headers: {
           "Content-Type": "application/json",
+          "Last-Modified": new Date(updated.modifiedOn).toUTCString(),
         },
-        statusCode: 400,
-        body: { error: "Not authorized to perform this action." },
+        statusCode: 200,
+        body: { updated },
       };
     } catch (e) {
       //TODO: Error logging

--- a/backend/src/apps/posts/entry-points/api/patch/patch-post.spec.js
+++ b/backend/src/apps/posts/entry-points/api/patch/patch-post.spec.js
@@ -9,27 +9,6 @@ describe("Controller for PATCH to /api/posts/:id endpoint", () => {
   let updatePost = vi.fn(async (post) => post);
   let patchPost;
 
-  beforeEach(() => {
-    patchPost = makePatchPost({ updatePost, handleAttachmentPreview });
-  });
-  test("Refuses to update a post without valid user credentials", async () => {
-    const post = makeFakeRawPost();
-    const request = {
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: { ...post },
-    };
-    const expected = {
-      headers: {
-        "Content-Type": "application/json",
-      },
-      statusCode: 400,
-      body: { error: "Not authorized to perform this action." },
-    };
-    const actual = await patchPost(request);
-    expect(actual).toEqual(expected);
-  });
   test("Successfully updates a post when new attachment is provided", async () => {
     const post = makeFakeRawPost();
     const user = { userId: post.userId };


### PR DESCRIPTION
Previously, authorization checks took place both through auth-middleware and in the controllers themselves. Auth-middleware would simply check if a current session was active and had a user. And for actions where a certain user was necessary (e.g. only the creator of a post can delete it), the corresponding controllers would check if the user making the request was authorized to make it. 

This was unnecessary complication and violated single-responsibility rule for controllers, who were now both checking for authorization and completing the request if the user was sufficiently authorized. This PR delegates all privilege and authorization checks to auth-middleware. Controllers affected are patchPost and deletePost.