### PR TITLE
Fix issue preventing posts service from returning accurate details about newly created post/reply

### DIFF
--- a/backend/src/apps/posts/data-access/posts-db.js
+++ b/backend/src/apps/posts/data-access/posts-db.js
@@ -1,15 +1,16 @@
 import _ from "lodash";
 export default function makePostsDb({ dbClient }) {
-  const dbColumnsToNormalizedProfile = {
+  const dbColumnsToNormalizedPost = {
     fk_uid: "userId",
     post_content: "postContent",
     img_cdn: "imgCdn",
     created_at: "createdAt",
     upvote_count: "upvoteCount",
+    is_reply: "isReply",
     parent_id: "parentId",
   };
 
-  const normalizedProfileToDbColumns = {
+  const normalizedPostToDbColumns = {
     userId: "fk_uid",
     postContent: "post_content",
     imgCdn: "img_cdn",
@@ -52,7 +53,7 @@ export default function makePostsDb({ dbClient }) {
     let result = await dbClient.from("posts_view").select();
     return {
       ...result,
-      data: format(result.data, dbColumnsToNormalizedProfile),
+      data: format(result.data, dbColumnsToNormalizedPost),
     };
   }
 
@@ -83,14 +84,14 @@ export default function makePostsDb({ dbClient }) {
     let result = await dbClient.from("replies_view").select().eq("id", postId);
     return {
       ...result,
-      data: format(result.data, dbColumnsToNormalizedProfile),
+      data: format(result.data, dbColumnsToNormalizedPost),
     };
   }
 
   async function update(updateDetails) {
     let result = await dbClient
       .from("posts")
-      .update({ ...renameKeys(updateDetails, normalizedProfileToDbColumns) })
+      .update({ ...renameKeys(updateDetails, normalizedPostToDbColumns) })
       .eq("id", updateDetails.id);
     return { ...result };
   }
@@ -103,17 +104,17 @@ export default function makePostsDb({ dbClient }) {
       .select();
     return {
       ...result,
-      data: format(result.data, dbColumnsToNormalizedProfile),
+      data: format(result.data, dbColumnsToNormalizedPost),
     };
   }
   async function insert(insertDetails) {
     let result = await dbClient
       .from("posts") // TODO: Add .env for "posts"
-      .insert({ ...renameKeys(insertDetails, normalizedProfileToDbColumns) })
+      .insert({ ...renameKeys(insertDetails, normalizedPostToDbColumns) })
       .select();
     return {
       ...result,
-      data: format(result.data, dbColumnsToNormalizedProfile),
+      data: format(result.data, dbColumnsToNormalizedPost),
     };
   }
 

--- a/backend/src/apps/posts/domain/use-cases/create-post.js
+++ b/backend/src/apps/posts/domain/use-cases/create-post.js
@@ -15,9 +15,7 @@ export default function makeCreatePost({ postsDb }) {
         `Error saving post to database: ${error.message}. Post creation failed.`
       );
     }
-    post.setCreatedAt(newPostRecord.createdAt);
-    post.setId(newPostRecord.id);
-    return post.getDTO();
-    //idea: only return createdAt, and postId, of database record created?
+    let newPost = makePost(...newPostRecord);
+    return newPost.getDTO();
   };
 }


### PR DESCRIPTION
The backend posts service is returning inaccurate details about the newly created post or reply. This PR fixes the issue and simplifies the code logic. It 
- Fixes a typo in dbColumnsToNormalizedPost, normalizedPostToDbColumns names
- Adds isReply to normalizedPostToDbColumns
- In create-post use case, returns new post record created by database, rather than modifying the post object that was passed in