### PR TITLE
Fix typo in votes-db

### DIFF
--- a/backend/src/apps/posts/data-access/votes-db.js
+++ b/backend/src/apps/posts/data-access/votes-db.js
@@ -1,5 +1,5 @@
 export default function makeVotesDb({ dbClient }) {
-  const normalizedProfileToDbColumns = {
+  const normalizedVoteToDbColumns = {
     voteCount: "delta_votes",
     userId: "uid",
     postId: "pid",
@@ -17,7 +17,7 @@ export default function makeVotesDb({ dbClient }) {
 
   async function vote(voteDetails) {
     let result = await dbClient.rpc("vote", {
-      ...renameKeys(voteDetails, normalizedProfileToDbColumns),
+      ...renameKeys(voteDetails, normalizedVoteToDbColumns),
     });
     return { ...result };
   }


### PR DESCRIPTION
The votes-db file in the backend uses an incorrect variable name. It uses normalizedProfileToDbColumns, which is incorrect because this is an interface for votes, not profiles. Accordingly, this PR renames normalizedProfileToDbColumns to normalizedVoteToDbColumns.