### PR TITLE
Refactor PostsList and optimize readability

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,6 +14,7 @@
         "eslint": "^8.44.0",
         "fs": "^0.0.1-security",
         "lodash": "^4.17.21",
+        "luxon": "^3.4.1",
         "pdf-img-convert": "^1.2.1",
         "pdf2pic": "^2.1.4",
         "prettier": "^2.8.8",
@@ -2689,6 +2690,14 @@
       "dev": true,
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.4.1.tgz",
+      "integrity": "sha512-2USspxOCXWGIKHwuQ9XElxPPYrDOJHDQ5DQ870CoD+CxJbBnRDIBCfhioUJJjct7BKOy80Ia8cVstIcIMb/0+Q==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/magic-string": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "eslint": "^8.44.0",
     "fs": "^0.0.1-security",
     "lodash": "^4.17.21",
+    "luxon": "^3.4.1",
     "pdf-img-convert": "^1.2.1",
     "pdf2pic": "^2.1.4",
     "prettier": "^2.8.8",

--- a/frontend/src/features/posts/components/list/PostsList.jsx
+++ b/frontend/src/features/posts/components/list/PostsList.jsx
@@ -1,17 +1,29 @@
-import React from "react";
+import React, { useEffect } from "react";
+import { DateTime } from "luxon";
 import { Link } from "react-router-dom";
+import { usePostsListContext } from "../../context/PostsListContext";
 
-const PostsList = ({ posts }) => {
+const PostsList = ({ allPosts }) => {
+  const { dispatch, displayed } = usePostsListContext();
+  const formatTimestamp = (timestamp) => {
+    const luxonDateTime = DateTime.fromISO(timestamp);
+    return luxonDateTime.toLocaleString(DateTime.DATETIME_MED);
+  };
+  useEffect(() => {
+    if (allPosts) {
+      dispatch({ type: "UPDATE_ALL_POSTS", payload: allPosts });
+    }
+  }, [allPosts]);
   return (
     <>
-      {posts && posts.length > 0 ? (
-        posts.map((post) => (
+      {displayed?.length ? (
+        displayed.map((post) => (
           <div
             className="flex flex-row w-full border-2 bg-slate-50/80 p-3"
-            key={post && post.id}
+            key={post?.id}
           >
             <Link
-              to={`/post/${post && post.id}`}
+              to={`/post/${post?.id}`}
               className="flex flex-col md:flex-row w-full items-center justify-between"
             >
               <span className="flex flex-col border p-3 rounded-full bg-amber-800/70 justify-center items-center">
@@ -29,12 +41,14 @@ const PostsList = ({ posts }) => {
                   />
                 </svg>
 
-                <p className="text-slate-50">{post && post.upvoteCount}</p>
+                <p className="text-slate-50">{post?.upvoteCount}</p>
               </span>
               <h2 className="text-4xl truncate text-ellipsis max-w-[45%]">
-                {post && post.title}
+                {post?.title}
               </h2>
-              <p className="font-light italic">{post && post.createdAt}</p>
+              <p className="font-light italic">
+                {formatTimestamp(post?.createdAt)}
+              </p>
             </Link>
           </div>
         ))

--- a/frontend/src/features/posts/components/list/SearchBar.jsx
+++ b/frontend/src/features/posts/components/list/SearchBar.jsx
@@ -1,7 +1,9 @@
 // credit: https://javascript.plainenglish.io/how-to-create-an-optimized-real-time-search-with-react-6dd4026f4fa9
 import React, { useEffect, useState } from "react";
+import { usePostsListContext } from "../../context/PostsListContext";
 
-const SearchBar = ({ onSearchSubmit, clearResults }) => {
+const SearchBar = () => {
+  const { dispatch } = usePostsListContext();
   const [term, setTerm] = useState("");
   const [debouncedTerm, setDebouncedTerm] = useState(term);
 
@@ -13,12 +15,10 @@ const SearchBar = ({ onSearchSubmit, clearResults }) => {
 
   // submit a new search
   useEffect(() => {
-    console.log(term);
     if (term !== "") {
-      onSearchSubmit(term);
+      dispatch({ type: "UPDATE_SEARCH_TERM", payload: term });
     } else {
-      console.log("clearing");
-      clearResults();
+      dispatch({ type: "RESET_DISPLAYED" });
     }
   }, [term]);
 

--- a/frontend/src/features/posts/components/list/SortSelect.jsx
+++ b/frontend/src/features/posts/components/list/SortSelect.jsx
@@ -1,0 +1,37 @@
+import { usePostsListContext } from "../../context/PostsListContext";
+const SortSelect = () => {
+  const { dispatch } = usePostsListContext();
+  const handleSortSelectChange = (e) => {
+    dispatch({ type: "UPDATE_SORT_OPTION", payload: e.target.value });
+  };
+  return (
+    <span className="flex items-center gap-3 p-1 border border-slate-400 ">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+        strokeWidth={1.5}
+        stroke="currentColor"
+        className="w-6 h-6"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M10.5 6h9.75M10.5 6a1.5 1.5 0 11-3 0m3 0a1.5 1.5 0 10-3 0M3.75 6H7.5m3 12h9.75m-9.75 0a1.5 1.5 0 01-3 0m3 0a1.5 1.5 0 00-3 0m-3.75 0H7.5m9-6h3.75m-3.75 0a1.5 1.5 0 01-3 0m3 0a1.5 1.5 0 00-3 0m-9.75 0h9.75"
+        />
+      </svg>
+
+      <select
+        name="sort-select"
+        id="sort-select"
+        className="p-2 bg-white rounded"
+        onChange={handleSortSelectChange}
+      >
+        <option value="createdAt">Time Created</option>
+        <option value="upvoteCount">Upvotes</option>
+      </select>
+    </span>
+  );
+};
+
+export default SortSelect;

--- a/frontend/src/features/posts/context/PostsListContext.jsx
+++ b/frontend/src/features/posts/context/PostsListContext.jsx
@@ -1,0 +1,64 @@
+import { createContext, useReducer, useMemo, useContext } from "react";
+const PostsListContext = createContext();
+export const usePostsListContext = () => useContext(PostsListContext);
+const sortDisplayedPosts = (displayed, sortSelect) => {
+  if (displayed) {
+    switch (sortSelect) {
+      case "createdAt":
+        return [
+          ...displayed.sort(
+            (a, b) => new Date(b[sortSelect]) - new Date(a[sortSelect])
+          ),
+        ];
+      case "upvoteCount":
+        return [...displayed.sort((a, b) => b[sortSelect] - a[sortSelect])];
+    }
+  }
+};
+export const postListContextReducer = (state, action) => {
+  switch (action.type) {
+    case "UPDATE_SEARCH_TERM":
+      const filtered = [
+        ...state.allPosts.filter((post) =>
+          post.title.toLowerCase().includes(action.payload.toLowerCase())
+        ),
+      ];
+      return {
+        ...state,
+        displayed: sortDisplayedPosts(filtered, state.sortOption),
+      };
+    case "UPDATE_SORT_OPTION":
+      return {
+        ...state,
+        sortOption: action.payload,
+        displayed: sortDisplayedPosts(state.displayed, action.payload),
+      };
+    case "UPDATE_ALL_POSTS":
+      return {
+        ...state,
+        allPosts: action.payload,
+        displayed: sortDisplayedPosts(action.payload, state.sortOption),
+      };
+    case "RESET_DISPLAYED":
+      return {
+        ...state,
+        displayed: sortDisplayedPosts(state.allPosts, state.sortOption),
+      };
+    default:
+      return state;
+  }
+};
+export const PostsListContextProvider = ({ children }) => {
+  const [state, dispatch] = useReducer(postListContextReducer, {
+    displayed: null,
+    allPosts: null,
+    sortOption: "createdAt", //not including search term because it is not considered on allPosts' update
+  });
+  const contextValue = useMemo(() => ({ ...state, dispatch }), [state]);
+
+  return (
+    <PostsListContext.Provider value={contextValue}>
+      {children}
+    </PostsListContext.Provider>
+  );
+};

--- a/frontend/src/pages/AllPosts.jsx
+++ b/frontend/src/pages/AllPosts.jsx
@@ -1,96 +1,31 @@
 import React from "react";
-import { useEffect, useState } from "react";
-import useAllPosts from "../features/posts/hooks/useAllPosts";
-import SearchBar from "../features/posts/components/SearchBar";
-import PostsList from "../features/posts/components/PostsList";
-import StatusNotification from "../features/notifications/components/StatusNotification";
-import PostsSkeleton from "../features/posts/components/PostsSkeleton";
+import { PostsListContextProvider } from "../features/posts/context/PostsListContext";
 import { StatusContextProvider } from "../features/notifications/context/StatusContext";
+import PostsList from "../features/posts/components/list/PostsList";
+import PostsSkeleton from "../features/posts/components/PostsSkeleton";
+import StatusNotification from "../features/notifications/components/StatusNotification";
+import useAllPosts from "../features/posts/hooks/useAllPosts";
+import SearchBar from "../features/posts/components/list/SearchBar";
+import SortSelect from "../features/posts/components/list/SortSelect";
 const AllPosts = () => {
   const { isLoading, isError, data: allPosts, error } = useAllPosts();
-  const [posts, setPosts] = useState(allPosts);
-  const [sortSelect, setSortSelect] = useState("createdAt");
-  const onSearchSubmit = (term) => {
-    if (allPosts) {
-      setPosts([
-        ...allPosts.filter((post) =>
-          post.title.toLowerCase().includes(term.toLowerCase())
-        ),
-      ]);
-    }
-  };
-  const clearResults = () => {
-    if (allPosts) {
-      setPosts(sortPosts([...allPosts]));
-    }
-  };
-  useEffect(() => {
-    if (allPosts) {
-      clearResults();
-    }
-  }, [allPosts]);
-
-  const sortPosts = (displayed) => {
-    switch (sortSelect) {
-      case "createdAt":
-        console.log("sort by date");
-        return [
-          ...displayed.sort(
-            (a, b) => new Date(b[sortSelect]) - new Date(a[sortSelect])
-          ),
-        ];
-      case "upvoteCount":
-        return [...displayed.sort((a, b) => b[sortSelect] - a[sortSelect])];
-    }
-  };
-  useEffect(() => {
-    if (posts) {
-      setPosts(sortPosts(posts));
-    }
-  }, [sortSelect]);
   return (
     <StatusContextProvider>
-      <div className="rounded flex shadow-md border m-3 w-11/12 gap-2 bg-slate-100/50 flex-col px-3 py-5 font-[700] text-center">
-        <span className="flex w-full justify-between mb-3 border-2 p-2">
-          <SearchBar
-            onSearchSubmit={onSearchSubmit}
-            clearResults={clearResults}
-          />
-          <span className="flex items-center gap-3 p-1 border border-slate-400 ">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-              strokeWidth={1.5}
-              stroke="currentColor"
-              className="w-6 h-6"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M10.5 6h9.75M10.5 6a1.5 1.5 0 11-3 0m3 0a1.5 1.5 0 10-3 0M3.75 6H7.5m3 12h9.75m-9.75 0a1.5 1.5 0 01-3 0m3 0a1.5 1.5 0 00-3 0m-3.75 0H7.5m9-6h3.75m-3.75 0a1.5 1.5 0 01-3 0m3 0a1.5 1.5 0 00-3 0m-9.75 0h9.75"
-              />
-            </svg>
-
-            <select
-              name="sort-select"
-              id="sort-select"
-              className="p-2 bg-white rounded"
-              onChange={(e) => setSortSelect(e.target.value)}
-            >
-              <option value="createdAt">Time Created</option>
-              <option value="upvoteCount">Upvotes</option>
-            </select>
+      <PostsListContextProvider>
+        <div className="rounded flex shadow-md border m-3 w-11/12 gap-2 bg-slate-100/50 flex-col px-3 py-5 font-[700] text-center">
+          <span className="flex w-full justify-between mb-3 border-2 p-2">
+            <SearchBar />
+            <SortSelect />
           </span>
-        </span>
-        {isLoading ? (
-          <PostsSkeleton />
-        ) : isError ? (
-          <StatusNotification status={"error"} msg={error.message} />
-        ) : (
-          <PostsList posts={posts} />
-        )}
-      </div>
+          {isLoading ? (
+            <PostsSkeleton />
+          ) : isError ? (
+            <StatusNotification status={"error"} msg={error.message} />
+          ) : (
+            <PostsList allPosts={allPosts} />
+          )}
+        </div>
+      </PostsListContextProvider>
     </StatusContextProvider>
   );
 };


### PR DESCRIPTION
AllPosts is managing the state variables related to current sort option, search term, and list of posts to display via prop drilling. This is getting quite complicated and code readability isn't ideal. This PR helps resolve that issue by making the following changes:
- Create PostsListContext for managing state of current sort option, search term, and updates to allPosts
- Move PostsList-relevant components to new 'list' directory under posts feature's components directory
- Refactor post-sorting select box into its own component
- Use Luxon to display each post's timestamps in more readable format