### PR TITLE
Make appearance of components more uniform and pleasant

### DIFF
--- a/frontend/dist/output.css
+++ b/frontend/dist/output.css
@@ -424,7 +424,7 @@ video {
 
 html {
   --tw-text-opacity: 1;
-  color: rgb(71 85 105 / var(--tw-text-opacity));
+  color: rgb(30 41 59 / var(--tw-text-opacity));
   font-family: Barlow, sans-serif;
   scroll-behavior: smooth;
 }
@@ -550,8 +550,20 @@ h1,
   bottom: 1.25rem;
 }
 
+.left-0 {
+  left: 0px;
+}
+
+.right-0 {
+  right: 0px;
+}
+
 .right-5 {
   right: 1.25rem;
+}
+
+.z-50 {
+  z-index: 50;
 }
 
 .m-2 {
@@ -607,8 +619,20 @@ h1,
   margin-right: 0.75rem;
 }
 
+.mt-1 {
+  margin-top: 0.25rem;
+}
+
 .mt-12 {
   margin-top: 3rem;
+}
+
+.mt-2 {
+  margin-top: 0.5rem;
+}
+
+.block {
+  display: block;
 }
 
 .inline {
@@ -788,12 +812,20 @@ h1,
   min-width: 0px;
 }
 
+.min-w-\[10em\] {
+  min-width: 10em;
+}
+
 .min-w-\[80\%\] {
   min-width: 80%;
 }
 
 .max-w-\[45\%\] {
   max-width: 45%;
+}
+
+.max-w-\[15em\] {
+  max-width: 15em;
 }
 
 .flex-1 {
@@ -830,6 +862,10 @@ h1,
 
 .animate-spin {
   animation: spin 1s linear infinite;
+}
+
+.list-none {
+  list-style-type: none;
 }
 
 .flex-row {
@@ -878,6 +914,17 @@ h1,
 
 .gap-5 {
   gap: 1.25rem;
+}
+
+.divide-y > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-y-reverse: 0;
+  border-top-width: calc(1px * calc(1 - var(--tw-divide-y-reverse)));
+  border-bottom-width: calc(1px * var(--tw-divide-y-reverse));
+}
+
+.divide-gray-100 > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-opacity: 1;
+  border-color: rgb(243 244 246 / var(--tw-divide-opacity));
 }
 
 .self-center {
@@ -1061,24 +1108,12 @@ h1,
   background-color: rgb(255 255 255 / var(--tw-bg-opacity));
 }
 
-.bg-gradient-to-b {
-  background-image: linear-gradient(to bottom, var(--tw-gradient-stops));
-}
-
-.bg-hero-pattern {
-  background-image: url('./assets/Oreti.png');
-}
-
 .bg-gradient-to-r {
   background-image: linear-gradient(to right, var(--tw-gradient-stops));
 }
 
-.from-slate-200 {
-  --tw-gradient-from: #e2e8f0 var(--tw-gradient-from-position);
-  --tw-gradient-from-position:  ;
-  --tw-gradient-to: rgb(226 232 240 / 0)  var(--tw-gradient-from-position);
-  --tw-gradient-to-position:  ;
-  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to);
+.bg-hero-pattern {
+  background-image: url('./assets/Oreti.png');
 }
 
 .from-blue-200 {
@@ -1087,11 +1122,6 @@ h1,
   --tw-gradient-to: rgb(191 219 254 / 0)  var(--tw-gradient-from-position);
   --tw-gradient-to-position:  ;
   --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to);
-}
-
-.to-blue-50 {
-  --tw-gradient-to: #eff6ff var(--tw-gradient-to-position);
-  --tw-gradient-to-position:  ;
 }
 
 .to-purple-200 {
@@ -1161,9 +1191,19 @@ h1,
   padding-right: 0.75rem;
 }
 
+.px-4 {
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+
 .px-5 {
   padding-left: 1.25rem;
   padding-right: 1.25rem;
+}
+
+.py-1 {
+  padding-top: 0.25rem;
+  padding-bottom: 0.25rem;
 }
 
 .py-2 {
@@ -1214,6 +1254,10 @@ h1,
   padding-right: 1.25rem;
 }
 
+.pt-1 {
+  padding-top: 0.25rem;
+}
+
 .pt-3 {
   padding-top: 0.75rem;
 }
@@ -1224,6 +1268,10 @@ h1,
 
 .text-center {
   text-align: center;
+}
+
+.text-start {
+  text-align: start;
 }
 
 .text-2xl {
@@ -1317,6 +1365,11 @@ h1,
   color: rgb(229 231 235 / var(--tw-text-opacity));
 }
 
+.text-gray-700 {
+  --tw-text-opacity: 1;
+  color: rgb(55 65 81 / var(--tw-text-opacity));
+}
+
 .text-red-800 {
   --tw-text-opacity: 1;
   color: rgb(153 27 27 / var(--tw-text-opacity));
@@ -1335,6 +1388,12 @@ h1,
 .text-white {
   --tw-text-opacity: 1;
   color: rgb(255 255 255 / var(--tw-text-opacity));
+}
+
+.shadow {
+  --tw-shadow: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
+  --tw-shadow-colored: 0 1px 3px 0 var(--tw-shadow-color), 0 1px 2px -1px var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
 .shadow-md {
@@ -1397,6 +1456,11 @@ body {
 
 .hover\:bg-blue-800\/80:hover {
   background-color: rgb(30 64 175 / 0.8);
+}
+
+.hover\:bg-gray-100:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgb(243 244 246 / var(--tw-bg-opacity));
 }
 
 .hover\:bg-orange-400\/90:hover {
@@ -1536,6 +1600,10 @@ body {
 }
 
 @media (min-width: 768px) {
+  .md\:absolute {
+    position: absolute;
+  }
+
   .md\:ml-5 {
     margin-left: 1.25rem;
   }
@@ -1552,12 +1620,20 @@ body {
     margin-right: 1.25rem;
   }
 
+  .md\:mt-0 {
+    margin-top: 0px;
+  }
+
   .md\:flex {
     display: flex;
   }
 
   .md\:hidden {
     display: none;
+  }
+
+  .md\:w-5\/6 {
+    width: 83.333333%;
   }
 
   .md\:w-\[25\%\] {
@@ -1572,12 +1648,20 @@ body {
     width: auto;
   }
 
+  .md\:w-11\/12 {
+    width: 91.666667%;
+  }
+
   .md\:flex-row {
     flex-direction: row;
   }
 
   .md\:flex-col {
     flex-direction: column;
+  }
+
+  .md\:flex-nowrap {
+    flex-wrap: nowrap;
   }
 
   .md\:items-start {
@@ -1588,8 +1672,16 @@ body {
     align-items: center;
   }
 
+  .md\:justify-start {
+    justify-content: flex-start;
+  }
+
   .md\:justify-end {
     justify-content: flex-end;
+  }
+
+  .md\:justify-between {
+    justify-content: space-between;
   }
 
   .md\:gap-0 {
@@ -1612,8 +1704,24 @@ body {
     align-self: flex-end;
   }
 
+  .md\:bg-blue-200\/50 {
+    background-color: rgb(191 219 254 / 0.5);
+  }
+
+  .md\:pr-2 {
+    padding-right: 0.5rem;
+  }
+
   .md\:pt-0 {
     padding-top: 0px;
+  }
+
+  .md\:text-start {
+    text-align: start;
+  }
+
+  .group:hover .md\:group-hover\:block {
+    display: block;
   }
 }
 

--- a/frontend/src/features/authentication/components/LoggedIn.jsx
+++ b/frontend/src/features/authentication/components/LoggedIn.jsx
@@ -16,7 +16,7 @@ const LoggedIn = () => {
     }
   }, [user]);
   return (
-    <div className="rounded flex shadow-md border m-3 w-5/6 gap-5 bg-slate-100/50 flex-col justify-center px-3 py-5 font-[700] text-center">
+    <div className="rounded flex shadow-md border m-3 w-11/12 gap-5 bg-slate-100/50 flex-col justify-center px-3 py-5 font-[700] text-center">
       {isLoading ? (
         <>
           <h1 className="text-5xl">Verifying your details...</h1>

--- a/frontend/src/features/authentication/components/LoggedOut.jsx
+++ b/frontend/src/features/authentication/components/LoggedOut.jsx
@@ -32,7 +32,7 @@ const LoggedOut = () => {
     }
   }, []);
   return (
-    <div className="rounded flex shadow-md border m-3 w-5/6 gap-5 bg-slate-100/50 flex-col justify-center px-3 py-5 font-[700] text-center">
+    <div className="rounded flex shadow-md border m-3 w-11/12 gap-5 bg-slate-100/50 flex-col justify-center px-3 py-5 font-[700] text-center">
       {isLoading ? (
         <>
           {" "}

--- a/frontend/src/features/authentication/hooks/useUser.js
+++ b/frontend/src/features/authentication/hooks/useUser.js
@@ -6,7 +6,11 @@ export default function useUser(overrides = {}) {
     queryKey: ["user"],
     queryFn: async () => {
       const user = await getCurrentUser();
-      return { ...user, ...overrides };
+      return {
+        ...user,
+        displayName: user?.displayName || user?.name,
+        ...overrides,
+      };
     },
     staleTime: 60 * 1000 * 60 * 24, // 24 hours,
     refetchOnWindowFocus: false,

--- a/frontend/src/features/profiles/components/BasicInformation.jsx
+++ b/frontend/src/features/profiles/components/BasicInformation.jsx
@@ -95,15 +95,15 @@ const BasicInformation = () => {
       </div>
       <div
         id="edit-pic"
-        className="flex flex-col md:flex-row w-full md:items-center md:gap-3 "
+        className="flex flex-col md:flex-row w-full md:items-center md:gap-3 justify-between"
       >
-        <p className="font-medium">Profile picture: </p>
+        <p className="font-medium text-start">Profile picture: </p>
         <div
           id="edit-pic-input"
-          className="flex justify-center self-center gap-5 flex-wrap"
+          className="flex justify-center mt-2 md:mt-0 md:justify-between  w-full  gap-5 flex-wrap md:flex-nowrap"
         >
           <img
-            className="self-center rounded-full w-20 h-20 border-2 border-blue-800"
+            className="self-center rounded-lg w-20 h-20 border border-slate-800"
             src={profilePic}
             alt="profile"
           />
@@ -153,7 +153,7 @@ const BasicInformation = () => {
                 d="M11.25 11.25l.041-.02a.75.75 0 011.063.852l-.708 2.836a.75.75 0 001.063.853l.041-.021M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9-3.75h.008v.008H12V8.25z"
               />
             </svg>
-            <p className="font-medium text-amber-800">
+            <p className="font-medium text-amber-800 md:text-start">
               Only .png, .jpg, .jpeg files allowed. Changes to your profile
               picture may take up to an hour to show up.
             </p>

--- a/frontend/src/features/profiles/components/MainDetails.jsx
+++ b/frontend/src/features/profiles/components/MainDetails.jsx
@@ -1,8 +1,6 @@
 import { useContext, useEffect } from "react";
-import { StatusContext } from "../../notifications/context/StatusContext";
 import { ProfileEditContext } from "../context/ProfileEditContext";
 const MainDetails = ({ user }) => {
-  const { status, statusMsg } = useContext(StatusContext);
   const { dispatch: profileDispatch } = useContext(ProfileEditContext);
   useEffect(() => {
     if (user) {
@@ -16,7 +14,7 @@ const MainDetails = ({ user }) => {
       className="flex flex-wrap flex-col md:flex-row items-center border-b-2 border-slate-50 py-5 w-full gap-5 wrap justify-center"
     >
       <img
-        className="self-center rounded-full w-40 h-40 border-2 border-blue-800"
+        className="self-center rounded-lg w-40 h-40 border"
         src={user?.profilePic}
         alt="profile"
       />
@@ -26,7 +24,7 @@ const MainDetails = ({ user }) => {
       >
         <h1 className="text-5xl">{user?.displayName || user?.name}</h1>{" "}
         {/* TODO: change to displayName */}
-        <h2 className="text-3xl italic">{user?.email}</h2>
+        <h2 className="text-2xl italic">{user?.email}</h2>
       </div>
     </div>
   );

--- a/frontend/src/layouts/RegularLayout.jsx
+++ b/frontend/src/layouts/RegularLayout.jsx
@@ -3,7 +3,7 @@ import { Outlet } from "react-router-dom";
 
 const RegularLayout = ({ user, setUser }) => {
   return (
-    <div className="flex flex-1 justify-center items-stretch  w-full bg-gradient-to-r from-blue-200 to-purple-200">
+    <div className="flex flex-1 justify-center items-stretch w-full bg-gradient-to-r from-blue-200 to-purple-200">
       <Outlet context={[user, setUser]} />
     </div>
   );

--- a/frontend/src/main.css
+++ b/frontend/src/main.css
@@ -3,7 +3,7 @@
 @tailwind utilities;
 @layer base {
   html {
-    @apply text-slate-600;
+    @apply text-slate-800;
     @apply font-plainText;
     @apply scroll-smooth;
   }

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -11,7 +11,7 @@ const Login = () => {
     window.location = AUTH_URL_GOOGLE;
   };
   return (
-    <div className="rounded flex shadow-md border m-3 w-5/6 gap-2 bg-slate-100/50 flex-col justify-center px-3 py-5 font-[700] text-center">
+    <div className="rounded flex shadow-md border m-3 w-11/12 gap-2 bg-slate-100/50 flex-col justify-center px-3 py-5 font-[700] text-center">
       {" "}
       <h2 className="text-4xl text-slate-900">Welcome back.</h2>
       <p>We're glad to see you again!</p>

--- a/frontend/src/pages/NotPermitted.jsx
+++ b/frontend/src/pages/NotPermitted.jsx
@@ -1,0 +1,19 @@
+import React from "react";
+import ReportButton from "../components/ReportButton";
+const NotPermitted = () => {
+  return (
+    <div className="rounded flex shadow-md border bg-cover bg-hero-pattern w-full">
+      <div className="bg-slate-50/70 flex flex-col justify-center px-3 py-5 font-[700] text-center gap-5 w-full">
+        <h1 className="text-5xl">Whoops!</h1>
+        <p className="text-2xl  self-center w-3/4">
+          If you're here, you've navigated to a page that doesn't seem to exist.
+          If it's supposed to exist, please let us know how you ended up here,
+          so we can fix it!
+        </p>
+        <ReportButton />
+      </div>
+    </div>
+  );
+};
+
+export default NotPermitted;

--- a/frontend/src/pages/Profile.jsx
+++ b/frontend/src/pages/Profile.jsx
@@ -11,7 +11,7 @@ const Profile = () => {
   return (
     <StatusContextProvider>
       <ProfileEditContextProvider>
-        <form className="rounded flex shadow-md border m-3 w-5/6 bg-slate-100/50 flex-col items-center px-3 py-5 font-[700] text-center">
+        <form className="rounded flex shadow-md border m-3 w-11/12 md:w-11/12 bg-slate-100/50 flex-col items-center px-3 py-5 font-[700] text-center">
           <MainDetails user={user} />
           <BasicInformation user={user} />
           <Socials user={user} />

--- a/frontend/src/pages/Signup.jsx
+++ b/frontend/src/pages/Signup.jsx
@@ -11,7 +11,7 @@ const Signup = () => {
     window.location = AUTH_URL_GOOGLE;
   };
   return (
-    <div className="rounded flex shadow-md border m-3 w-5/6 bg-slate-100/50 flex-col justify-center px-3 py-5 font-[700] text-center">
+    <div className="rounded flex shadow-md border m-3 w-11/12 bg-slate-100/50 flex-col justify-center px-3 py-5 font-[700] text-center">
       <h2 className="text-4xl text-slate-900">Welcome!</h2>
       <p>We're excited for you to join the CV Circle!</p>
       <span className="flex flex-col items-center justify-center mt-12">


### PR DESCRIPTION
Currently, certain pages have different container widths than others. For example, the Profile page and AllPosts page have different widths (w-5/6 and w-11/12, respectively). This affects the perceived 'seamlessness' when switching between components. This PR makes the following changes:
- Use same width for containers so switching to a different page isn't as jarring
- Adjust placement of flex children in BasicInformation's profile picture edit div