### PR TITLE
Fix routes with incorrect restrictions

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -52,14 +52,11 @@ const App = () => {
             {!user && <Route path="/login" element={<Login />} />}
             {!user && <Route path="/signup" element={<Signup />} />}
             <Route path="/logged-in" element={<LoggedIn />} />
-            {user && <Route path="/logout" element={<Logout />} />}
+            <Route path="/logout" element={<Logout />} />
             {user && <Route path="/create-post" element={<CreatePost />} />}
-            {user && (
-              <Route path="/post/:id/:updated?" element={<SinglePost />} />
-            )}
+            <Route path="/post/:id/:updated?" element={<SinglePost />} />
             <Route path="/edit-post/:id" element={<EditPost />} />
             <Route path="/edit-profile" element={<Profile />} />
-
             <Route path="*" element={<NotFound />} />
           </Route>
         </Route>


### PR DESCRIPTION
Currently, the route restriction setup was making the LoggedOut component impossible to access at all, and the SinglePost component impossible to access when logged out. The expected behavior is that the LoggedOut component should be accessible upon logout, and the SinglePost component should be accessible regardless of authentication status. This PR fixes the issue by making this change:
- Remove conditional check for user on routes to SinglePost and LoggedOut