### PR TITLE
Fix issue with users cache 

### DIFF
--- a/backend/src/apps/users/__test__/fixtures/cache.js
+++ b/backend/src/apps/users/__test__/fixtures/cache.js
@@ -1,0 +1,21 @@
+import { vi } from "vitest";
+
+let xAddSpy = vi.fn(async (data) => {
+  return await "1526919030474-55";
+});
+let hSetSpy = vi.fn(async (data) => {
+  return await 1;
+});
+let hExists = vi.fn(async (hash, field) => {
+  return await 1;
+});
+let hDelSpy = vi.fn(async (hash, field) => {
+  return await 1;
+});
+const mockCacheClient = {
+  xAdd: xAddSpy,
+  hSet: hSetSpy,
+  hExists: hExists,
+  hDel: hDelSpy,
+};
+export default mockCacheClient;

--- a/backend/src/apps/users/__test__/fixtures/profile.js
+++ b/backend/src/apps/users/__test__/fixtures/profile.js
@@ -10,7 +10,7 @@ const FAKE_USER_EMAIL = faker.internet.email({
   firstName: FAKE_USER_GIVEN_NAME,
   lastName: FAKE_USER_FAMILY_NAME,
 });
-const FAKE_USER_ID = faker.number.bigInt(100000000000000000000n);
+const FAKE_USER_ID = faker.string.numeric(21);
 const FAKE_USER_PROFILE_PIC = faker.image.avatar();
 
 export default {

--- a/backend/src/apps/users/__test__/fixtures/session.js
+++ b/backend/src/apps/users/__test__/fixtures/session.js
@@ -1,0 +1,24 @@
+const { faker } = require("@faker-js/faker");
+import { makeFakeRawUser } from "./user";
+
+const FAKE_SESSION_ID = faker.string.nanoid(32);
+const FAKE_ORIGINAL_MAX_AGE = 86400;
+const FAKE_EXPIRES = faker.date.future();
+const FAKE_SECURE = faker.datatype.boolean();
+const FAKE_HTTP_ONLY = faker.datatype.boolean();
+const FAKE_PATH = faker.internet.url();
+const FAKE_SAME_SITE = faker.datatype.boolean();
+export default function makeFakeSession(overrides) {
+  const user = makeFakeRawUser();
+  const cookie = {
+    originalMaxAge: FAKE_ORIGINAL_MAX_AGE,
+    expires: FAKE_EXPIRES,
+    secure: FAKE_SECURE,
+    httpOnly: FAKE_HTTP_ONLY,
+    path: FAKE_PATH,
+    sameSite: FAKE_SAME_SITE,
+  };
+  const sessionId = overrides?.sessionId || FAKE_SESSION_ID;
+  const session = { sessionId, cookie, user, ...overrides };
+  return session;
+}

--- a/backend/src/apps/users/__test__/fixtures/user.js
+++ b/backend/src/apps/users/__test__/fixtures/user.js
@@ -1,6 +1,6 @@
 const { faker } = require("@faker-js/faker");
 
-const FAKE_USER_ID = faker.number.bigInt(100000000000000000000n);
+const FAKE_USER_ID = faker.string.numeric(21);
 const FAKE_USER_NAME = faker.person.fullName();
 const FAKE_USER_EMAIL = faker.internet.email();
 const FAKE_USER_PROFILE_PIC = faker.image.avatar();

--- a/backend/src/apps/users/data-access/sessions-cache.js
+++ b/backend/src/apps/users/data-access/sessions-cache.js
@@ -25,6 +25,6 @@ export default function makeSessionsCache({ cacheClient }) {
     return keyDeletionStatus;
   }
   async function checkPreviouslyStreamed(sessionId) {
-    return await cacheClient.hGet("session_keys", sessionId);
+    return await cacheClient.hExists("session_keys", sessionId);
   }
 }

--- a/backend/src/apps/users/data-access/sessions-cache.js
+++ b/backend/src/apps/users/data-access/sessions-cache.js
@@ -1,8 +1,30 @@
 export default function makeSessionsCache({ cacheClient }) {
-  return Object.freeze({ add });
+  return Object.freeze({ add, remove });
   async function add(streamId, sessionInformation) {
     const session = JSON.stringify(sessionInformation);
     console.log(session);
-    return await cacheClient.xAdd(streamId, "*", { session });
+    let previouslyStreamed = await checkPreviouslyStreamed(
+      sessionInformation.sessionId
+    );
+    if (!previouslyStreamed) {
+      let addedKey = await cacheClient.xAdd(streamId, "*", { session });
+      console.log(addedKey);
+      await cacheClient.hSet(
+        "session_keys",
+        sessionInformation.sessionId,
+        addedKey
+      );
+      return addedKey;
+    }
+  }
+  async function remove(streamId, sessionId) {
+    const session = JSON.stringify({ sessionId });
+    console.log(session);
+    let sessionTombstone = await cacheClient.xAdd(streamId, "*", { session });
+    let keyDeletionStatus = await cacheClient.hDel("session_keys", sessionId);
+    return keyDeletionStatus;
+  }
+  async function checkPreviouslyStreamed(sessionId) {
+    return await cacheClient.hGet("session_keys", sessionId);
   }
 }

--- a/backend/src/apps/users/data-access/sessions-cache.spec.js
+++ b/backend/src/apps/users/data-access/sessions-cache.spec.js
@@ -1,0 +1,69 @@
+import { describe, test, beforeEach, afterEach, vi, expect } from "vitest";
+import cacheClient from "../__test__/fixtures/cache.js";
+import makeSessionsCache from "./sessions-cache.js";
+import makeFakeSession from "../__test__/fixtures/session.js";
+describe("Sessions cache", () => {
+  let sessionsCache;
+  beforeEach(() => {
+    sessionsCache = makeSessionsCache({ cacheClient });
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+  test("Successfully adds a session to the cache when its ID is not found in the hash", async () => {
+    cacheClient.hExists.mockImplementation(async () => {
+      return await 0;
+    });
+    const fakeSession = makeFakeSession();
+    const expectedSession = { session: JSON.stringify(fakeSession) };
+    const streamId = "cache_auth";
+
+    let addedKey = await sessionsCache.add(streamId, fakeSession);
+    const hExistsArgs = cacheClient.hExists.mock.calls[0];
+    const xAddArgs = cacheClient.xAdd.mock.calls[0];
+    const hSetArgs = cacheClient.hSet.mock.calls[0];
+    expect(cacheClient.hExists).toHaveBeenCalledTimes(1);
+    expect(cacheClient.xAdd).toHaveBeenCalledTimes(1);
+    expect(cacheClient.hSet).toHaveBeenCalledTimes(1);
+    expect(addedKey).toBeTruthy();
+    expect(hExistsArgs[0]).toEqual("session_keys");
+    expect(hExistsArgs[1]).toEqual(fakeSession.sessionId);
+    expect(xAddArgs[0]).toEqual(streamId);
+    expect(xAddArgs[1]).toEqual("*");
+    expect(xAddArgs[2]).toEqual(expectedSession);
+    expect(hSetArgs[0]).toEqual("session_keys");
+    expect(hSetArgs[1]).toEqual(fakeSession.sessionId);
+    expect(hSetArgs[2]).toEqual(addedKey);
+  });
+  test("Does not add a session to the cache when its ID is found in the hash", async () => {
+    const fakeSession = makeFakeSession();
+    const streamId = "cache_auth";
+    let addedKey = await sessionsCache.add(streamId, fakeSession);
+    const hExistsArgs = cacheClient.hExists.mock.calls[0];
+    expect(cacheClient.hExists).toHaveBeenCalledTimes(1);
+    expect(cacheClient.xAdd).toHaveBeenCalledTimes(0);
+    expect(cacheClient.hSet).toHaveBeenCalledTimes(0);
+    expect(hExistsArgs[0]).toEqual("session_keys");
+    expect(hExistsArgs[1]).toEqual(fakeSession.sessionId);
+    expect(addedKey).toBeUndefined();
+  });
+  test("Successfully invalidates user record", async () => {
+    const fakeSession = makeFakeSession();
+    const { sessionId } = fakeSession;
+    const streamId = "cache_auth";
+    const tombstone = { session: JSON.stringify({ sessionId }) };
+    let keyDeletionStatus = await sessionsCache.remove(streamId, sessionId);
+
+    expect(cacheClient.xAdd).toHaveBeenCalledTimes(1);
+    expect(cacheClient.hDel).toHaveBeenCalledTimes(1);
+    const xAddArgs = cacheClient.xAdd.mock.calls[0];
+    const hDelArgs = cacheClient.hDel.mock.calls[0];
+
+    expect(xAddArgs[0]).toEqual(streamId);
+    expect(xAddArgs[1]).toEqual("*");
+    expect(xAddArgs[2]).toEqual(tombstone);
+    expect(hDelArgs[0]).toEqual("session_keys");
+    expect(hDelArgs[1]).toEqual(sessionId);
+    expect(keyDeletionStatus).toEqual(1);
+  });
+});

--- a/backend/src/apps/users/domain/use-cases/cache-user.js
+++ b/backend/src/apps/users/domain/use-cases/cache-user.js
@@ -1,0 +1,5 @@
+export default function makeCacheUser({ sessionsCache }) {
+  return async function cacheUser(session) {
+    return await sessionsCache.add("cache_auth", session);
+  };
+}

--- a/backend/src/apps/users/domain/use-cases/cache-user.spec.js
+++ b/backend/src/apps/users/domain/use-cases/cache-user.spec.js
@@ -1,0 +1,26 @@
+import { describe, test, expect, beforeEach, vi } from "vitest";
+import { makeFakeUser } from "../../__test__/fixtures/user";
+import makeCacheUser from "./cache-user";
+import makeFakeSession from "../../__test__/fixtures/session";
+describe("Updating cache with new records tests", () => {
+  let sessionsCache;
+  let cacheUser;
+  beforeEach(() => {
+    sessionsCache = {
+      add: vi.fn(async (streamId, session) => {
+        return Promise.resolve(session);
+      }),
+    };
+    cacheUser = makeCacheUser({ sessionsCache });
+  });
+
+  test("Successfully adds session to stream", async () => {
+    const streamId = "cache_auth";
+    const session = makeFakeSession();
+    cacheUser(session);
+    expect(sessionsCache.add).toHaveBeenCalledTimes(1);
+    const [streamIdArg, sessionArg] = sessionsCache.add.mock.calls[0];
+    expect(streamIdArg).toEqual(streamId);
+    expect(sessionArg).toEqual(session);
+  });
+});

--- a/backend/src/apps/users/domain/use-cases/index.js
+++ b/backend/src/apps/users/domain/use-cases/index.js
@@ -2,14 +2,16 @@ import makeUser from "../entities/user/index.js";
 import makeSaveUser from "./save-user.js";
 import makeHandlePicture from "./handle-picture.js";
 import { imagesDb, usersDb, sessionsCache } from "../../data-access/index.js";
-import makeUpdateCache from "./update-cache.js";
+import makeCacheUser from "./cache-user.js";
+import makeUncacheUser from "./uncache-user.js";
 const saveUser = makeSaveUser({
   usersDb,
   makeUser,
 });
-const updateCache = makeUpdateCache({ sessionsCache });
-const authenticationService = Object.freeze({ saveUser, updateCache });
+const cacheUser = makeCacheUser({ sessionsCache });
+const uncacheUser = makeUncacheUser({ sessionsCache });
+const authenticationService = Object.freeze({ saveUser, cacheUser });
 const handlePicture = makeHandlePicture({ imagesDb });
 
 export default authenticationService;
-export { saveUser, updateCache, handlePicture };
+export { saveUser, cacheUser, uncacheUser, handlePicture };

--- a/backend/src/apps/users/domain/use-cases/uncache-user.js
+++ b/backend/src/apps/users/domain/use-cases/uncache-user.js
@@ -1,0 +1,5 @@
+export default function makeUncacheUser({ sessionsCache }) {
+  return async function uncacheUser(sessionId) {
+    return await sessionsCache.remove("cache_auth", sessionId);
+  };
+}

--- a/backend/src/apps/users/domain/use-cases/uncache-user.spec.js
+++ b/backend/src/apps/users/domain/use-cases/uncache-user.spec.js
@@ -1,0 +1,25 @@
+import { describe, test, expect, beforeEach, vi } from "vitest";
+import makeUncacheUser from "./uncache-user";
+import makeFakeSession from "../../__test__/fixtures/session";
+describe("Cache invalidation tests", () => {
+  let sessionsCache;
+  let uncacheUser;
+  beforeEach(() => {
+    sessionsCache = {
+      remove: vi.fn(async (streamId, sessionId) => {
+        return Promise.resolve(sessionId);
+      }),
+    };
+    uncacheUser = makeUncacheUser({ sessionsCache });
+  });
+
+  test("Successfully invalidates user in cache", async () => {
+    const streamId = "cache_auth";
+    const { sessionId } = makeFakeSession();
+    uncacheUser(sessionId);
+    expect(sessionsCache.remove).toHaveBeenCalledTimes(1);
+    const [streamIdArg, sessionIdArg] = sessionsCache.remove.mock.calls[0];
+    expect(streamIdArg).toEqual(streamId);
+    expect(sessionIdArg).toEqual(sessionId);
+  });
+});

--- a/backend/src/apps/users/domain/use-cases/update-cache.js
+++ b/backend/src/apps/users/domain/use-cases/update-cache.js
@@ -1,5 +1,0 @@
-export default function makeUpdateCache({ sessionsCache }) {
-  return async function updateCache(session) {
-    return await sessionsCache.add("cache_auth", session);
-  };
-}

--- a/backend/src/apps/users/entry-points/api/get/get-auth-success.js
+++ b/backend/src/apps/users/entry-points/api/get/get-auth-success.js
@@ -1,8 +1,8 @@
-export default function makeGetAuthSuccess({ updateCache }) {
+export default function makeGetAuthSuccess({ cacheUser }) {
   return function (httpRequest) {
     if (httpRequest.user) {
       console.log(httpRequest.session.cookie);
-      updateCache({
+      cacheUser({
         sessionId: httpRequest.sessionId,
         cookie: httpRequest.session.cookie,
         user: httpRequest.user,

--- a/backend/src/apps/users/entry-points/api/post/post-logout.js
+++ b/backend/src/apps/users/entry-points/api/post/post-logout.js
@@ -1,7 +1,7 @@
-export default function makePostLogout({ updateCache }) {
+export default function makePostLogout({ uncacheUser }) {
   return function (httpRequest) {
     if (httpRequest.sessionStore) {
-      updateCache({ sessionId: httpRequest.sessionId });
+      uncacheUser(httpRequest.sessionId);
       httpRequest.logOut((err) => {
         if (err) {
           return {

--- a/backend/src/apps/users/entry-points/api/users-controller.js
+++ b/backend/src/apps/users/entry-points/api/users-controller.js
@@ -1,7 +1,8 @@
 import {
   saveUser,
   handlePicture,
-  updateCache,
+  cacheUser,
+  uncacheUser,
 } from "../../domain/use-cases/index.js";
 import authenticator from "../../domain/services/authenticator/index.js";
 import makeGetGoogleAuth from "./get/get-google-auth.js";
@@ -24,8 +25,8 @@ const getGithubAuthCallback = makeGetGithubAuthCallback({
   authGithubCallback,
 });
 
-const getAuthSuccess = makeGetAuthSuccess({ updateCache });
-const postLogout = makePostLogout({ updateCache });
+const getAuthSuccess = makeGetAuthSuccess({ cacheUser });
+const postLogout = makePostLogout({ uncacheUser });
 const patchUser = makePatchUser({ saveUser, handlePicture });
 const userController = Object.freeze({
   getGoogleAuth,


### PR DESCRIPTION
Currently, the Redis cache_auth stream and the Kafka message topics receive copies of active session data each time a request is made to the /success endpoint (e.g. on browser refresh). This is because the controller at the /success endpoint calls the updateCache use case regardless of whether the active session has already been previously streamed. As a result, the Redis cache stream and Kafka message brokers are receiving and processing records unnecessarily. 
This PR fixes that issue by making the following changes:
- Split sessions-cache's add function into two functions - add and remove. 
- Use Redis hset data structure to track which session IDs have already been streamed previously. 
- In sessions-cache's add function, only add records into cache_auth stream if they are not present in hset.
- In sessions-cache's remove function, send tombstone session record and delete session ID from hset
- Split the updateCache use case into two use cases - cacheUser and uncacheUser. These call add and remove in sessions-cache, respectively.
- Update all imports
- Update all tests