### PR TITLE
Change posts feature's PDF processor to pdf2pic due to unfixed bugs in pdf-img-convert package

### DIFF
--- a/backend/src/apps/posts/Dockerfile
+++ b/backend/src/apps/posts/Dockerfile
@@ -2,6 +2,8 @@ FROM node:18
 WORKDIR /app
 COPY package.json .
 ARG NODE_ENV
+RUN apt-get update && apt-get install -y graphicsmagick
+RUN apt-get update && apt-get install -y ghostscript
 RUN if [ "$NODE_ENV" = "development" ]; \
     then npm install; \
     else npm install --omit=dev; \

--- a/backend/src/apps/posts/domain/services/file-converter/index.js
+++ b/backend/src/apps/posts/domain/services/file-converter/index.js
@@ -1,9 +1,21 @@
-import { convert } from "pdf-img-convert"; //TODO:Proper import
+import { fromBuffer } from "pdf2pic";
 import makePdfToImageConverter from "./pdf-to-image-converter.js";
-const pdfToImageConverter = makePdfToImageConverter({ convert });
+const pdfToImageConverter = makePdfToImageConverter({
+  convert: fromBuffer,
+});
 const pdfToImage = pdfToImageConverter({
-  page_numbers: [1],
-  base64: true,
+  imageOptions: {
+    format: "png",
+    width: 768,
+    height: 1056,
+    density: 600,
+  },
+  configuration: [
+    1,
+    {
+      responseType: "buffer",
+    },
+  ],
 });
 
 export default Object.freeze({ pdfToImage });

--- a/backend/src/apps/posts/domain/services/file-converter/pdf-to-image-converter.js
+++ b/backend/src/apps/posts/domain/services/file-converter/pdf-to-image-converter.js
@@ -1,7 +1,10 @@
 export default function makePdfToImageConverter({ convert }) {
-  return function pdfToImageConverter(options) {
+  // convert = fromBuffer
+  return function pdfToImageConverter({ imageOptions, configuration }) {
     return Object.freeze({
-      convert: (file) => convert(file, options),
+      convert: async (file) =>
+        await convert(file?.data, imageOptions)(...configuration),
+
       isBase64: () => options.base64,
     });
   };

--- a/backend/src/apps/posts/domain/services/pdf-preview/pdf-preview.js
+++ b/backend/src/apps/posts/domain/services/pdf-preview/pdf-preview.js
@@ -3,24 +3,10 @@ export default function buildMakePdfPreview({ fileConverter }) {
     if (!file) {
       throw new Error("File must be provided.");
     }
-    let pdfArray = await fileConverter.convert(file.data);
-    let pdfBuffer = makeBuffer(pdfArray);
-
+    let converted = await fileConverter.convert(file);
     return Object.freeze({
-      get: () => pdfBuffer, // default returns buffer
-      getPreviewBuffer: () => pdfBuffer,
-      getPreviewArray: () => pdfArray,
+      get: () => converted.buffer, // default returns buffer
+      getFileInformation: () => converted,
     });
   };
-
-  //TODO:Consider moving to different file?
-  function makeBuffer(pdfArray) {
-    let pdfBuffer;
-    if (fileConverter.isBase64() === true) {
-      pdfBuffer = Buffer.from(...pdfArray, "base64");
-    } else {
-      pdfBuffer = Buffer.from(...pdfArray);
-    }
-    return pdfBuffer;
-  }
 }

--- a/backend/src/apps/posts/package.json
+++ b/backend/src/apps/posts/package.json
@@ -20,12 +20,14 @@
     "express": "^4.18.2",
     "express-fileupload": "^1.4.0",
     "express-session": "^1.17.3",
-    "pdf-img-convert": "^1.2.1",
+    "pdf2pic": "3.0.1",
+    "gm": "^1.25.0",
     "kafkajs": "2.2.4",
     "@kafkajs/confluent-schema-registry": "3.3.0",
     "redis": "4.6.7",
     "connect-redis": "7.1.0",
-    "lodash": "^4.17.21"
+    "lodash": "^4.17.21",
+    "pdf-img-convert": "1.2.0"
   },
   "devDependencies": {
     "@faker-js/faker": "^8.0.2",


### PR DESCRIPTION
Currently, the pdf-img-convert package is being used for converting PDF files to images. This worked well until certain bugs were introduced into the package. They have not yet been fixed. (See [here](https://github.com/ol-th/pdf-img-convert.js/issues/42) and here](https://github.com/ol-th/pdf-img-convert.js/issues/43).) 

As a result, the pdf-img-convert package is being replaced with the pdf2pic package. Although the latter works, it is noticeably slower and requires certain binaries to be installed. If the pdf-img-convert package is fixed, the posts feature will go back to using pdf-img-convert.

This PR introduces the following changes:
- Remove pdf-img-convert from package.json, add pdf2pic
- Add RUN commands in posts Dockerfile to install needed binaries
- Replace pdf-img-convert configuration in file-converter and pdf-preview files with pdf2pic configuration