### PR TITLE
Fix minor testing issues

### DIFF
--- a/backend/src/apps/posts/domain/services/extension-generator/extension-generator.js
+++ b/backend/src/apps/posts/domain/services/extension-generator/extension-generator.js
@@ -1,3 +1,4 @@
+/* istanbul ignore file */
 export default function buildExtensionGenerator({ uniqueId }) {
   return function generateExtension(posterId) {
     let extension = posterId + "/" + uniqueId.makeId() + ".png";

--- a/backend/src/apps/posts/package.json
+++ b/backend/src/apps/posts/package.json
@@ -29,12 +29,9 @@
   },
   "devDependencies": {
     "@faker-js/faker": "^8.0.2",
-    "vite": "4.4.6",
-    "@vitest/coverage-istanbul": "^0.32.2",
-    "@vitest/ui": "^0.32.2",
-    "@web-std/file": "^3.0.2",
-    "supertest": "^6.3.3",
-    "vitest": "^0.32.0",
-    "nyc": "^15.1.0"
+    "@vitest/coverage-istanbul": "^0.34.3",
+    "happy-dom": "10.11.1",
+    "vitest": "^0.34.3",
+    "@web-std/file": "^3.0.2"
   }
 }


### PR DESCRIPTION
The test packages in posts feature's package.json are inconsistent. Some are unused as well. This PR cleans up that part of the posts feature's package.json and adds one istanbul skip hint in extension-generator.
Changes introduced are:
- Add istanbul coverage skip hint for extension generator
- Cleanup test related devDependencies packages