### PR TITLE
Remove unused getReplyById method in posts-db

### DIFF
--- a/backend/src/apps/posts/data-access/posts-db.js
+++ b/backend/src/apps/posts/data-access/posts-db.js
@@ -80,14 +80,6 @@ export default function makePostsDb({ dbClient }) {
     }
   }
 
-  async function getReplyById(postId) {
-    let result = await dbClient.from("replies_view").select().eq("id", postId);
-    return {
-      ...result,
-      data: format(result.data, dbColumnsToNormalizedPost),
-    };
-  }
-
   async function update(updateDetails) {
     let result = await dbClient
       .from("posts")
@@ -120,7 +112,6 @@ export default function makePostsDb({ dbClient }) {
 
   return Object.freeze({
     getAll,
-    getReplyById,
     getById,
     insert,
     update,


### PR DESCRIPTION
Currently, the postsDb module contains a function called getReplyById. This function is no longer used, so this PR removes it.