### PR TITLE
Fix post entity not handling empty strings for necessary properties properly

### DIFF
--- a/backend/src/apps/posts/domain/entities/post/post.js
+++ b/backend/src/apps/posts/domain/entities/post/post.js
@@ -23,13 +23,13 @@ export default function buildMakePost() {
     if (!userId) {
       throw new Error("Post must have an author.");
     }
-    if (!title && !isReply) {
+    if (!title?.trim() && !isReply) {
       throw new Error("Post must have a title.");
     }
-    if (!postContent) {
+    if (!postContent?.trim()) {
       throw new Error("Post must have content.");
     }
-    if (!imgCdn && !isReply) {
+    if (!imgCdn?.trim() && !isReply) {
       throw new Error("Post must have image.");
     }
     let replies = {};


### PR DESCRIPTION
Currently, the posts entity does not throw an error if it is passed a string containing only whitespaces (e.g. "    ") for a property that's necessary (like a title). This PR fixes this issue by introducing the following change:
- Use trim() method to ensure strings containing only whitespaces are caught