### PR TITLE
Fix error status not showing up on AllPosts

### DIFF
--- a/frontend/src/features/posts/components/list/PostsList.jsx
+++ b/frontend/src/features/posts/components/list/PostsList.jsx
@@ -1,20 +1,42 @@
-import React, { useEffect } from "react";
+import React, { useContext, useEffect } from "react";
 import { DateTime } from "luxon";
 import { Link } from "react-router-dom";
 import { usePostsListContext } from "../../context/PostsListContext";
-
-const PostsList = ({ allPosts }) => {
-  const { dispatch, displayed } = usePostsListContext();
+import { useAllPosts } from "../../hooks";
+import PostsSkeleton from "../PostsSkeleton";
+import { StatusContext } from "../../../notifications/context/StatusContext";
+const PostsList = () => {
+  const { status: allPostsStatus, error, data: allPosts } = useAllPosts();
+  const { dispatch: statusDispatch } = useContext(StatusContext);
+  const { dispatch: postsListDispatch, displayed } = usePostsListContext();
   const formatTimestamp = (timestamp) => {
     const luxonDateTime = DateTime.fromISO(timestamp);
     return luxonDateTime.toLocaleString(DateTime.DATETIME_MED);
   };
   useEffect(() => {
     if (allPosts) {
-      dispatch({ type: "UPDATE_ALL_POSTS", payload: allPosts });
+      postsListDispatch({ type: "UPDATE_ALL_POSTS", payload: allPosts });
     }
   }, [allPosts]);
-  return (
+  useEffect(() => {
+    if (allPostsStatus !== "error") {
+      statusDispatch({
+        type: "UPDATE_STATUS",
+        payload: { status: allPostsStatus, show: false },
+      });
+    } else {
+      statusDispatch({
+        type: "UPDATE_STATUS",
+        payload: {
+          status: "error",
+          statusMsg: error.message,
+        },
+      });
+    }
+  }, [allPostsStatus]);
+  return allPostsStatus === "loading" ? (
+    <PostsSkeleton />
+  ) : (
     <>
       {displayed?.length ? (
         displayed.map((post) => (

--- a/frontend/src/pages/AllPosts.jsx
+++ b/frontend/src/pages/AllPosts.jsx
@@ -2,13 +2,10 @@ import React from "react";
 import { PostsListContextProvider } from "../features/posts/context/PostsListContext";
 import { StatusContextProvider } from "../features/notifications/context/StatusContext";
 import PostsList from "../features/posts/components/list/PostsList";
-import PostsSkeleton from "../features/posts/components/PostsSkeleton";
 import StatusNotification from "../features/notifications/components/StatusNotification";
-import useAllPosts from "../features/posts/hooks/useAllPosts";
 import SearchBar from "../features/posts/components/list/SearchBar";
 import SortSelect from "../features/posts/components/list/SortSelect";
 const AllPosts = () => {
-  const { isLoading, isError, data: allPosts, error } = useAllPosts();
   return (
     <StatusContextProvider>
       <PostsListContextProvider>
@@ -17,13 +14,8 @@ const AllPosts = () => {
             <SearchBar />
             <SortSelect />
           </span>
-          {isLoading ? (
-            <PostsSkeleton />
-          ) : isError ? (
-            <StatusNotification status={"error"} msg={error.message} />
-          ) : (
-            <PostsList allPosts={allPosts} />
-          )}
+          <PostsList />
+          <StatusNotification popup={"true"} />
         </div>
       </PostsListContextProvider>
     </StatusContextProvider>


### PR DESCRIPTION
Currently, AllPosts is not showing an error status message if fetching the list of posts fails, due to bugs with the way StatusNotification was implemented in the AllPosts component. This PR fixes that issue by introducing the following changes:

- Dispatch status update of fetching all posts through PostsList
- Render status notification only passing popup prop
- Render PostsSkeleton conditionally in PostsList