### PR TITLE
Enable user account deletion on frontend

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -24,18 +24,20 @@ import EditPost from "./pages/EditPost";
 import RegularLayout from "./layouts/RegularLayout";
 const App = () => {
   const [voteHistory, setVoteHistory] = useSessionStorage("voteHistory", {});
-  let { data } = useUser({ voteHistory } || {});
+  let { data, error } = useUser({ voteHistory } || {});
   const [user, setUser] = useState(null);
   useEffect(() => {
     if (data && !voteHistory) {
       // load existing vote history if no changes during session
-      console.log("no vote history found");
       setVoteHistory(data.voteHistory);
     }
     if (data) {
       setUser(data);
     }
-  }, [data]);
+    if (error && user) {
+      setUser(null);
+    }
+  }, [data, error]);
   const router = createBrowserRouter(
     createRoutesFromElements(
       <Route

--- a/frontend/src/features/profiles/components/AccountActions.jsx
+++ b/frontend/src/features/profiles/components/AccountActions.jsx
@@ -3,17 +3,23 @@ import { ProfileEditContext } from "../context/ProfileEditContext";
 import { StatusContext } from "../../notifications/context/StatusContext";
 import { useUserUpdate } from "../hooks";
 import StatusNotification from "../../notifications/components/StatusNotification";
+import DeletePrompt from "./DeletePrompt";
 const AccountActions = () => {
   const [deletePromptActive, setDeletePromptActive] = useState(false);
   const { profile } = useContext(ProfileEditContext);
   const { dispatch } = useContext(StatusContext);
-  const { status, mutateAsync: update, error } = useUserUpdate();
+  const { status: updateStatus, mutateAsync: update, error } = useUserUpdate();
   const updateProfile = async (e) => {
     e.preventDefault();
     update(profile);
   };
+  const handleDelete = async (e) => {
+    e.preventDefault();
+    setDeletePromptActive(!deletePromptActive);
+    //delete();
+  };
   useEffect(() => {
-    if (status === "success") {
+    if (updateStatus === "success") {
       dispatch({
         type: "UPDATE_STATUS",
         payload: {
@@ -22,7 +28,7 @@ const AccountActions = () => {
             "Profile updated successfully. Feel free to log in again to see your changes!",
         },
       });
-    } else if (status === "loading") {
+    } else if (updateStatus === "loading") {
       dispatch({
         type: "UPDATE_STATUS",
         payload: {
@@ -31,51 +37,30 @@ const AccountActions = () => {
         },
       });
     }
-  }, [status]);
+  }, [updateStatus]);
   return (
-    <div className="flex flex-col md:flex-row w-full md:items-center m-2 ">
-      <button
-        className="whitespace-nowrap text-slate-50 disabled:bg-amber-800/50 bg-amber-800 hover:bg-amber-800/90 focus:ring-4 focus:outline-none focus:ring-[#24292F]/50 font-medium rounded-lg px-5 py-2.5 flex items-center justify-center self-center m-2 md:mr-10"
-        onClick={updateProfile}
-        disabled={status === "loading"}
-        type="Submit"
-      >
-        Save Changes
-      </button>
-      <button
-        className="whitespace-nowrap disabled:bg-red-500/50 text-slate-50 bg-red-500 hover:bg-red-500/90  focus:ring-4 focus:outline-none focus:ring-[#24292F]/50 font-medium rounded-lg px-5 py-2.5 flex items-center justify-center self-center m-2 md:mr-5"
-        onClick={(e) => setDeletePromptActive(!deletePromptActive)}
-        disabled={status === "loading"}
-      >
-        {deletePromptActive ? "Cancel" : "Delete Account"}
-      </button>
-      {deletePromptActive && (
-        <div className="flex flex-col md:flex-row md:items-center">
-          <label
-            htmlFor="delete-warning"
-            className="text-left text-amber-800 md:mr-1"
-          >
-            Warning! This will delete ALL your posts, comments, and votes.
-            Please enter your email to confirm you wish to delete this account.
-          </label>
-
-          <input
-            className="border border-slate-800  p-2 rounded bg-slate-50/50 focus:bg-slate-50 grow text-amber-800"
-            type="text"
-            name="email"
-            required="required"
-            placeholder={profile.email}
-          />
-          <button
-            className="whitespace-nowrap text-slate-50 bg-red-500 hover:bg-red-500/90 disabled:bg-red-500/50  focus:ring-4 focus:outline-none focus:ring-[#24292F]/50 font-medium rounded-lg px-5 py-2.5 flex items-center justify-center self-center m-2 md:mr-5"
-            onClick={(e) => setDeletePromptActive(!deletePromptActive)}
-            disabled={status === "loading"}
-          >
-            Delete Anyway
-          </button>
-        </div>
-      )}
-      <StatusNotification status={status} />
+    <div className="flex flex-col md:flex-row w-full md:items-center m-2 p-2 ">
+      <div className="w-full flex md:w-auto mb-4 md:mb-0">
+        <button
+          className="whitespace-nowrap text-slate-50 disabled:bg-amber-800/50 bg-amber-800 hover:bg-amber-800/90 focus:ring-4 focus:outline-none focus:ring-[#24292F]/50 font-medium rounded-lg px-5 py-2.5 flex items-center justify-center self-center mr-10"
+          onClick={updateProfile}
+          disabled={updateStatus === "loading"}
+        >
+          Save Changes
+        </button>
+        <button
+          className="whitespace-nowrap disabled:bg-red-500/50 text-slate-50 bg-red-500 hover:bg-red-500/90  focus:ring-4 focus:outline-none focus:ring-[#24292F]/50 font-medium rounded-lg px-5 py-2.5 flex items-center justify-center self-center mr-5"
+          onClick={handleDelete}
+          disabled={updateStatus === "loading"}
+          type="submit"
+        >
+          {deletePromptActive ? "Cancel" : "Delete Account"}
+        </button>
+      </div>
+      <DeletePrompt
+        activeContext={[deletePromptActive, setDeletePromptActive]}
+        disabled={updateStatus === "loading"}
+      />
     </div>
   );
 };

--- a/frontend/src/features/profiles/components/DeletePrompt.jsx
+++ b/frontend/src/features/profiles/components/DeletePrompt.jsx
@@ -1,0 +1,103 @@
+import { useContext, useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { useUserDelete } from "../hooks";
+import { StatusContext } from "../../notifications/context/StatusContext";
+import { ProfileEditContext } from "../context/ProfileEditContext";
+
+const DeletePrompt = ({ activeContext, disabled }) => {
+  const [active, setActive] = activeContext;
+  const navigate = useNavigate();
+  const { dispatch: statusDispatch } = useContext(StatusContext);
+  const { status: deleteStatus, mutateAsync: remove, error } = useUserDelete();
+
+  const [confirmation, setConfirmation] = useState("");
+  const { profile } = useContext(ProfileEditContext);
+  const handleConfirmDelete = async (e) => {
+    e.preventDefault();
+    if (confirmation === profile?.email) {
+      setActive(!active);
+      await remove();
+    }
+  };
+  useEffect(() => {
+    if (deleteStatus === "loading") {
+      statusDispatch({
+        type: "UPDATE_STATUS",
+        payload: {
+          status: "loading",
+          statusMsg: "Account is being deleted.",
+        },
+      });
+    } else if (deleteStatus === "success") {
+      statusDispatch({
+        type: "UPDATE_STATUS",
+        payload: {
+          status: "success",
+          statusMsg: "Account has been deleted. Feel free to log out.",
+        },
+      });
+      navigate(".", { relative: "path" });
+    } else if (deleteStatus === "error") {
+      statusDispatch({
+        type: "UPDATE_STATUS",
+        payload: {
+          status: "error",
+          statusMsg: error.message,
+        },
+      });
+    }
+  }, [deleteStatus]);
+  return (
+    active && (
+      <div className="flex flex-col gap-3 p-3 rounded text-red-800 border border-red-300 rounded-lg bg-red-50 mt-2 md:mt-0">
+        <label
+          htmlFor="delete-warning"
+          className="flex items-center gap-3  text-left text-amber-800 md:mr-5"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={1.5}
+            stroke="currentColor"
+            className="w-6 h-6 shrink-0"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z"
+            />
+          </svg>
+          Warning! This will delete ALL your posts, comments, and votes. Please
+          enter your email to confirm you wish to delete this account.
+        </label>
+        <div className="flex items-center gap-5">
+          <input
+            className="border border-slate-800  p-2 rounded  bg-slate-50/50 focus:bg-slate-50 min-w-[30%] text-amber-800 "
+            type="text"
+            name="email"
+            required="required"
+            value={confirmation}
+            onChange={(e) => {
+              setConfirmation(e.target.value);
+            }}
+            placeholder={profile?.email}
+          />
+          <button
+            className="whitespace-nowrap text-slate-50 bg-red-500 hover:bg-red-500/90 disabled:bg-red-500/50  focus:ring-4 focus:outline-none focus:ring-[#24292F]/50 font-medium rounded-lg px-5 py-2.5 flex items-center justify-center self-center"
+            onClick={handleConfirmDelete}
+            disabled={
+              confirmation !== profile?.email ||
+              deleteStatus === "loading" ||
+              disabled === "true"
+            } //deleteStatus === "loading" || disabled === "true"
+          >
+            Delete Anyway
+          </button>
+        </div>
+      </div>
+    )
+  );
+};
+
+export default DeletePrompt;

--- a/frontend/src/features/profiles/hooks/index.js
+++ b/frontend/src/features/profiles/hooks/index.js
@@ -1,2 +1,3 @@
 import useUserUpdate from "./useUserUpdate";
-export { useUserUpdate };
+import useUserDelete from "./useUserDelete";
+export { useUserUpdate, useUserDelete };

--- a/frontend/src/features/profiles/hooks/useUserDelete.js
+++ b/frontend/src/features/profiles/hooks/useUserDelete.js
@@ -1,0 +1,14 @@
+import { useQueryClient, useMutation } from "@tanstack/react-query";
+import { deleteUser } from "../services";
+
+export default function useUserUpdate() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (userId) => deleteUser(userId),
+    onSuccess: (data) => {
+      queryClient.invalidateQueries(["posts"]);
+      queryClient.invalidateQueries(["user"]);
+    },
+    retry: 0,
+  });
+}

--- a/frontend/src/features/profiles/services/index.js
+++ b/frontend/src/features/profiles/services/index.js
@@ -22,4 +22,18 @@ const updateUser = async (user) => {
     };
   }
 };
-export { updateUser };
+const deleteUser = async () => {
+  try {
+    let { data } = await axios.delete(`${DOMAIN}/api/auth/user`);
+    return data?.deleted;
+  } catch (e) {
+    console.log(e);
+    let { data, status } = e.response || {};
+    let errorMsg = data?.error;
+    throw {
+      message: errorMsg || "An unknown error has happened!",
+      status: status || e.code,
+    };
+  }
+};
+export { updateUser, deleteUser };


### PR DESCRIPTION
Currently, the backend users feature contains a DELETE /user endpoint, but there is no way to reach that endpoint from the frontend. This PR allows a user to delete their account. It introduces the following changes:
- Create useUserDelete hook, the corresponding React query, and service
- Refactor account deletion confirmation prompt to its own component, DeletePrompt
- Use useUserDelete hook in DeletePrompt to delete a user
- Update state after user is deleted