### PR TITLE
Add route restriction for EditPost and Profile pages

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -57,8 +57,8 @@ const App = () => {
             <Route path="/logout" element={<Logout />} />
             {user && <Route path="/create-post" element={<CreatePost />} />}
             <Route path="/post/:id/:updated?" element={<SinglePost />} />
-            <Route path="/edit-post/:id" element={<EditPost />} />
-            <Route path="/edit-profile" element={<Profile />} />
+            {user && <Route path="/edit-post/:id" element={<EditPost />} />}
+            {user && <Route path="/edit-profile" element={<Profile />} />}
             <Route path="*" element={<NotFound />} />
           </Route>
         </Route>


### PR DESCRIPTION
Currently, a user may access the EditPost and Profile pages even if they are not logged in. These routes only make sense if a user is currently logged in, so the PR makes the following change:
- Disable routes to EditPost and Profile page unless user is currently logged in