### PR TITLE
Refactor code in users feature's saveUser use case and postLogout controller

### DIFF
--- a/backend/src/apps/users/domain/use-cases/index.js
+++ b/backend/src/apps/users/domain/use-cases/index.js
@@ -11,6 +11,7 @@ const saveUser = makeSaveUser({
 });
 const cacheUser = makeCacheUser({ sessionsCache });
 const uncacheUser = makeUncacheUser({ sessionsCache });
+const removeUser = makeRemoveUser({ usersDb });
 const authenticationService = Object.freeze({
   saveUser,
   cacheUser,
@@ -18,7 +19,6 @@ const authenticationService = Object.freeze({
   removeUser,
 });
 const handlePicture = makeHandlePicture({ imagesDb });
-const removeUser = makeRemoveUser({ usersDb });
 
 export default authenticationService;
 export { saveUser, cacheUser, uncacheUser, handlePicture, removeUser };

--- a/backend/src/apps/users/domain/use-cases/save-user.js
+++ b/backend/src/apps/users/domain/use-cases/save-user.js
@@ -1,4 +1,5 @@
-export default function makeSaveUser({ usersDb, makeUser }) {
+import makeUser from "../entities/user/index.js";
+export default function makeSaveUser({ usersDb }) {
   return async function saveUser({ ...profileDetails }, onlyUpdate = false) {
     const user = makeUser({ ...profileDetails });
     let data;
@@ -19,7 +20,6 @@ export default function makeSaveUser({ usersDb, makeUser }) {
       throw new Error("User details could not be retrieved");
     }
     const savedUser = makeUser({ ...data[0] });
-
     return savedUser;
   };
 }

--- a/backend/src/apps/users/domain/use-cases/save-user.spec.js
+++ b/backend/src/apps/users/domain/use-cases/save-user.spec.js
@@ -4,11 +4,9 @@ import makeSaveUser from "./save-user";
 
 describe("Authenticate user use case tests", () => {
   let usersDb;
-  let makeUser;
   let saveUser;
   let isolateProfileDetails;
   let fakeRawUser = makeFakeUser().getDTO();
-  let fakeUserEntity = makeFakeUser();
   beforeEach(() => {
     usersDb = {
       upsert: vi.fn(async (user) => {
@@ -19,22 +17,16 @@ describe("Authenticate user use case tests", () => {
       }),
     };
     isolateProfileDetails = vi.fn(() => fakeRawUser);
-    makeUser = vi.fn(() => fakeUserEntity);
     saveUser = makeSaveUser({
       usersDb,
-      makeUser,
       isolateProfileDetails,
     });
   });
 
   test("Successfully saves user", async () => {
     let savedUser = await saveUser(fakeRawUser);
-    expect(makeUser).toHaveBeenCalledTimes(2);
     expect(usersDb.upsert).toHaveBeenCalledTimes(1);
     expect(usersDb.update).toHaveBeenCalledTimes(0);
-
-    let makeUserArgs = makeUser.mock.calls[0][0];
-    expect(makeUserArgs).toEqual(fakeRawUser);
 
     let usersDbUpsertArgs = usersDb.upsert.mock.calls[0][0];
     expect(usersDbUpsertArgs.userId).toEqual(fakeRawUser.userId);
@@ -65,12 +57,8 @@ describe("Authenticate user use case tests", () => {
 
   test("Calls usersDb update function when onlyUpdate is set to true", async () => {
     let updatedUser = await saveUser(fakeRawUser, true);
-    expect(makeUser).toHaveBeenCalledTimes(2);
     expect(usersDb.update).toHaveBeenCalledTimes(1);
     expect(usersDb.upsert).toHaveBeenCalledTimes(0);
-
-    let makeUserArgs = makeUser.mock.calls[0][0];
-    expect(makeUserArgs).toEqual(fakeRawUser);
 
     let usersDbUpdateArgs = usersDb.update.mock.calls[0][0];
     expect(usersDbUpdateArgs.userId).toEqual(fakeRawUser.userId);

--- a/backend/src/apps/users/entry-points/api/post/post-logout.js
+++ b/backend/src/apps/users/entry-points/api/post/post-logout.js
@@ -1,55 +1,47 @@
+import withErrorHandling from "../../../utils/with-error-handling.js";
+
 export default function makePostLogout({ uncacheUser }) {
-  return function (httpRequest) {
-    if (httpRequest.sessionStore) {
-      uncacheUser(httpRequest.sessionId);
-      httpRequest.logOut((err) => {
-        if (err) {
-          return {
-            headers: {
-              "Content-Type": "application/json",
-            },
-            statusCode: 400,
-            body: {
-              error: "Logout unsuccessful: could not clear session.",
-            },
-          };
-        }
-      });
-      httpRequest.session.destroy((err) => {
-        if (err) {
-          return {
-            headers: {
-              "Content-Type": "application/json",
-            },
-            statusCode: 400,
-            body: {
-              error: "Logout unsuccessful: could not clear session.",
-            },
-          };
-        }
-      });
-      return {
-        headers: {
-          "Content-Type": "application/json",
-          "Set-Cookie":
-            "connect.sid=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT",
-        },
-        statusCode: 200,
-        body: {
-          success: true,
+  return async function (httpRequest) {
+    try {
+      if (httpRequest.sessionStore) {
+        await uncacheUser(httpRequest.sessionId);
+        withErrorHandling(
+          () => httpRequest.logOut,
+          () => httpRequest.session.destroy
+        )("Logout unsuccessful: could not clear session.");
+
+        return {
+          headers: {
+            "Content-Type": "application/json",
+            "Set-Cookie":
+              "connect.sid=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT",
+          },
           statusCode: 200,
-          message: "Logout successful.",
-        },
-      };
-    } else {
+          body: {
+            success: true,
+            statusCode: 200,
+            message: "Logout successful.",
+          },
+        };
+      } else {
+        return {
+          headers: {
+            "Content-Type": "application/json",
+          },
+          statusCode: 400,
+          body: {
+            error: "Logout unsuccessful: no session found.",
+          },
+        };
+      }
+    } catch (e) {
+      //TODO: Error logging
+      console.log(e);
+
       return {
-        headers: {
-          "Content-Type": "application/json",
-        },
+        headers: { "Content-Type": "application/json" },
         statusCode: 400,
-        body: {
-          error: "Logout unsuccessful: no session found.",
-        },
+        body: { error: e.message },
       };
     }
   };

--- a/backend/src/apps/users/entry-points/api/post/post-logout.spec.js
+++ b/backend/src/apps/users/entry-points/api/post/post-logout.spec.js
@@ -10,7 +10,7 @@ describe("Controller for POST to /logout endpoint", () => {
   afterEach(() => {
     vi.restoreAllMocks();
   });
-  test("Successfully logs out user", () => {
+  test("Successfully logs out user", async () => {
     const request = {
       sessionStore: {},
       logOut: () => {},
@@ -30,10 +30,10 @@ describe("Controller for POST to /logout endpoint", () => {
         message: "Logout successful.",
       },
     };
-    const actual = postLogout(request);
+    const actual = await postLogout(request);
     expect(actual).toEqual(expected);
   });
-  test("Returns error if no session found", () => {
+  test("Returns error if no session found", async () => {
     const request = {};
     const expected = {
       headers: {
@@ -44,7 +44,26 @@ describe("Controller for POST to /logout endpoint", () => {
         error: "Logout unsuccessful: no session found.",
       },
     };
-    const actual = postLogout(request);
+    const actual = await postLogout(request);
+    expect(actual).toEqual(expected);
+  });
+
+  test("Returns error response when error is thrown", async () => {
+    let error = { message: "Error" };
+    uncacheUser.mockImplementation(() => {
+      throw new Error(error.message);
+    });
+    const request = {
+      sessionStore: {},
+      logOut: () => {},
+      session: { destroy: () => {} },
+    };
+    const expected = {
+      headers: { "Content-Type": "application/json" },
+      statusCode: 400,
+      body: { error: error.message },
+    };
+    const actual = await postLogout(request);
     expect(actual).toEqual(expected);
   });
 });


### PR DESCRIPTION
In both the saveUser and postLogout modules, there is an opportunity for refactoring the code. saveUser can directly import the makeUser module since saveUser is a use case. postLogout can use the withErrorHandling util to avoid repeating the same error handling in httpRequest.logOut and httpRequest.session.destroy. 
Accordingly, this PR introduces the following changes:
- saveUser imports the makeUser module directly
- postLogout uses the withErrorHandling util and also wraps its happy path logic in a try/catch statement, just like all other controllers