### PR TITLE
Make kafka authentication streams stable

### DIFF
--- a/backend/docker-compose.dev.yml
+++ b/backend/docker-compose.dev.yml
@@ -17,7 +17,16 @@ services:
       - /app/node_modules
     environment:
       - NODE_ENV=development
-    command: npm run dev
+    command:
+      - bash
+      - -c
+      - |
+        while [ $(curl -s -o /dev/null -w %{http_code} -X POST -d '{"ksql": "DESCRIBE keyed_session_details;"}' -H "Content-Type: application/vnd.ksql.v1+json" http://ksqldb:8088/ksql) -ne 200 ];
+        do echo "Waiting for keyed_session_details stream to be up..."
+        sleep 5; 
+        done; 
+        echo "Keyed_session_details stream is ready!"
+        npm run dev
   users:
     image: cvcircle/users:dev
     build:

--- a/backend/docker-compose.prod.yml
+++ b/backend/docker-compose.prod.yml
@@ -17,7 +17,16 @@ services:
         NODE_ENV: production
     environment:
       - NODE_ENV=production
-    command: node entry-points/server.js
+    command:
+      - bash
+      - -c
+      - |
+        while [ $(curl -s -o /dev/null -w %{http_code} -X POST -d '{"ksql": "DESCRIBE keyed_session_details;"}' -H "Content-Type: application/vnd.ksql.v1+json" http://ksqldb:8088/ksql) -ne 200 ];
+        do echo "Waiting for keyed_session_details stream to be up..."
+        sleep 5; 
+        done; 
+        echo "Keyed_session_details stream is ready!"
+        npm run dev
   users:
     image: cvcircle/users
     build:

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -9,6 +9,7 @@ services:
     depends_on:
       - users
       - posts
+    restart: always
 
   zookeeper:
     image: confluentinc/cp-zookeeper:latest
@@ -19,6 +20,7 @@ services:
     volumes:
       - zookeeper-data:/var/lib/zookeeper/data
       - zookeeper-log:/var/lib/zookeeper/log
+    restart: always
 
   users-redis:
     image: redis
@@ -50,6 +52,9 @@ services:
       KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
       KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 100
+      KAFKA_LOG_DIRS: /var/lib/kafka/data
+      KAFKA_LOG_DIR: /var/lib/kafka/data
+    restart: always
 
   schema-registry:
     image: confluentinc/cp-schema-registry:latest
@@ -99,7 +104,6 @@ services:
         /etc/confluent/docker/run &
         /home/appuser/connectors-config 8083
         sleep infinity
-
   ksqldb:
     # *-----------------------------*
     # To connect to ksqlDB CLI

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -104,6 +104,7 @@ services:
         /etc/confluent/docker/run &
         /home/appuser/connectors-config 8083
         sleep infinity
+
   ksqldb:
     # *-----------------------------*
     # To connect to ksqlDB CLI

--- a/backend/src/apps/messaging/kafka-connect/connectors-config
+++ b/backend/src/apps/messaging/kafka-connect/connectors-config
@@ -28,11 +28,17 @@ curl -X POST -H "Content-Type: application/json" --data '
 sleep 2
 echo -e "\nCreating necessary topics:"
 retries=0
-while [ $(curl -s -o /dev/null -w %{http_code} -X POST http://ksqldb:8088/ksql -d '{"ksql": "CREATE STREAM IF NOT EXISTS source_records WITH (KAFKA_TOPIC='\''kafka_auth'\'', KEY_FORMAT='\''KAFKA'\'', VALUE_FORMAT='\''AVRO'\'');CREATE STREAM IF NOT EXISTS unkeyed_session_details AS SELECT CAST(EXTRACTJSONFIELD(BODY['\''session'\''], '\''$.sessionId'\'') AS STRING) AS ID, CAST(EXTRACTJSONFIELD(BODY['\''session'\''], '\''$.cookie'\'') AS STRING) AS cookie, CAST(EXTRACTJSONFIELD(BODY['\''session'\''], '\''$.user'\'') AS STRING) AS user from source_records;SET '\''auto.offset.reset'\'' = '\''earliest'\'';CREATE STREAM IF NOT EXISTS keyed_session_details WITH (KAFKA_TOPIC='\''keyed_session_details'\'') AS SELECT * FROM unkeyed_session_details PARTITION BY ID;"}') -ne 200 ] ; do
-  echo -e "\t" $(date) " Stream creation state not good (waiting for 200)"
-  sleep 30
-done
-echo "Topics created successfully!"
+
+streams=$(curl -X POST http://ksqldb:8088/ksql -d '{"ksql": "SHOW STREAMS;"}')
+echo "Found these streams:" $streams
+if [[ $streams != *"SOURCE_RECORDS"* ]] || [[ $streams != *"UNKEYED_SESSION_DETAILS"* ]] || [[ $streams != *"KEYED_SESSION_DETAILS"* ]]; then
+  echo "Need to create streams. Creating..."
+  while [ $(curl -s -o /dev/null -w %{http_code} -X POST http://ksqldb:8088/ksql -d '{"ksql": "CREATE STREAM IF NOT EXISTS source_records WITH (KAFKA_TOPIC='\''kafka_auth'\'', KEY_FORMAT='\''KAFKA'\'', VALUE_FORMAT='\''AVRO'\'');CREATE OR REPLACE STREAM unkeyed_session_details AS SELECT CAST(EXTRACTJSONFIELD(BODY['\''session'\''], '\''$.sessionId'\'') AS STRING) AS ID, CAST(EXTRACTJSONFIELD(BODY['\''session'\''], '\''$.cookie'\'') AS STRING) AS cookie, CAST(EXTRACTJSONFIELD(BODY['\''session'\''], '\''$.user'\'') AS STRING) AS user from source_records;CREATE OR REPLACE STREAM keyed_session_details WITH (KAFKA_TOPIC='\''keyed_session_details'\'') AS SELECT * FROM unkeyed_session_details PARTITION BY ID;"}') -ne 200 ] ; do
+    echo -e "\t" $(date) " Stream creation state not good (waiting for 200)"
+    sleep 30
+  done
+  echo "Topics created successfully!"
+fi
 
 <<comment
 sleep 2


### PR DESCRIPTION
Currently, the streams immediately become unstable and fluctuate in status each time the ksqldb and kafka-connect containers restart (as in the case of an unexpected host container shutdown.) They are then unusable, and the containers need to be recreated for functionality to resume. 

This is occurring because connectors-config (the current bash script being used to generate these streams) tells KSQLdb to recreate the streams on container restart. However, KSQLdb fails to do this because the Kafka Connect consumer group still contains active consumers (the previous streams). 

An extra layer of complexity arises from the fact that KAFKA_AUTO_CREATE_TOPICS_ENABLE is currently set to "true". So when the Kafka consumer in the posts service tries to consume the 'keyed_session_topic' information, the topic is automatically created. This may take place _before_ the CSAS keyed_session_details topic is created, causing a conflict.

To fix these issues, this PR introduces the following changes:
- Update connectors-config to first check if authentication streams already exist, and to only create the streams if they do not
- Update Compose files to first check if keyed_session_details stream exists before starting posts service
- Ensure broker logs are being stored correctly 
- Ensure all containers are automatically restarted except ksqldb, schema-registry, and kafka-connect (which should be started after broker is ready)