### PR TITLE
Fix issue of descendant replies disappearing on parent reply edit

### DIFF
--- a/backend/src/apps/posts/__test__/fixtures/constants.js
+++ b/backend/src/apps/posts/__test__/fixtures/constants.js
@@ -5,7 +5,7 @@ const uniqueId = Object.freeze({
 });
 //TODO: Add constants for table names & rows
 const FAKE_POST_ID = 1;
-const FAKE_POST_CREATED_AT = faker.date.anytime();
+const FAKE_POST_CREATED_AT = faker.date.anytime().toString();
 const FAKE_USER_ID = faker.string.numeric(21);
 const FAKE_POST_TITLE = faker.lorem.sentence();
 const FAKE_POST_CONTENT = faker.lorem.paragraph(3);

--- a/backend/src/apps/posts/domain/entities/post/post.js
+++ b/backend/src/apps/posts/domain/entities/post/post.js
@@ -32,9 +32,13 @@ export default function buildMakePost() {
     if (!imgCdn?.trim() && !isReply) {
       throw new Error("Post must have image.");
     }
-    let replies = {};
-    if (rest?.replies) {
-      replies = rest.replies;
+    if (replies?.constructor === String) {
+      // frontend sends replies property as JSON string since the form is sent as multipart/form-data
+      try {
+        replies = JSON.parse(replies);
+      } catch (e) {}
+    } else if (replies?.constructor !== Object) {
+      replies = {};
     }
     return Object.freeze({
       getId: () => id,

--- a/backend/src/apps/posts/domain/entities/post/post.spec.js
+++ b/backend/src/apps/posts/domain/entities/post/post.spec.js
@@ -9,6 +9,7 @@ describe("Post entity tests", () => {
   afterEach(() => {
     vi.restoreAllMocks();
   });
+
   it("sets isReply to boolean result of regex match test if isReply exists", () => {
     const inputDetails = makeFakeRawPost({ isReply: "true" });
     const post = makePost(inputDetails);
@@ -29,7 +30,8 @@ describe("Post entity tests", () => {
     const overrides = { title: null, isReply: true };
     const expectedPost = makeFakePostEntity(overrides);
     const inputDetails = makeFakeRawPost({ ...overrides });
-    expect(inputDetails).toEqual(expectedPost.getDTO());
+    const actual = makePost(inputDetails);
+    expect(actual.getDTO()).toEqual(expectedPost.getDTO());
   });
 
   it("throws error without post content", () => {
@@ -46,7 +48,25 @@ describe("Post entity tests", () => {
     const overrides = { imgCdn: null, isReply: true };
     const expectedPost = makeFakePostEntity(overrides);
     const inputDetails = makeFakeRawPost(overrides);
-    expect(inputDetails).toEqual(expectedPost.getDTO());
+    const actual = makePost(inputDetails);
+    expect(actual.getDTO()).toEqual(expectedPost.getDTO());
+  });
+
+  it("correctly sets replies JSON property if replies argument is JSON string", () => {
+    const replies = { 2: makeFakeRawPost({ id: 2 }) };
+    const overrides = { replies: JSON.stringify(replies) };
+    const expectedPost = makeFakePostEntity({ replies });
+    const inputDetails = makeFakeRawPost(overrides);
+    const actual = makePost(inputDetails);
+    expect(actual.getDTO()).toEqual(expectedPost.getDTO());
+  });
+
+  it("sets replies to an empty object if replies argument is not an object", () => {
+    const overrides = { replies: null };
+    const expectedPost = makeFakePostEntity();
+    const inputDetails = makeFakeRawPost(overrides);
+    const actual = makePost(inputDetails);
+    expect(actual.getDTO()).toEqual(expectedPost.getDTO());
   });
 
   it("sets image", () => {

--- a/frontend/src/features/replies/components/form/ReplyForm.jsx
+++ b/frontend/src/features/replies/components/form/ReplyForm.jsx
@@ -13,6 +13,7 @@ const ReplyForm = ({ original, user }) => {
     userId: user?.userId || "",
     file: null,
     path: original.path || "",
+    replies: original.replies,
     isReply: true,
   };
   const [post, setPost] = useState({

--- a/frontend/src/features/replies/hooks/useReplyMutation.js
+++ b/frontend/src/features/replies/hooks/useReplyMutation.js
@@ -1,13 +1,21 @@
 import { useQueryClient, useMutation } from "@tanstack/react-query";
 import { updatePost, createPost } from "../../posts/services";
 import setWith from "lodash/setWith";
+import transform from "lodash/transform";
+import isPlainObject from "lodash/isPlainObject";
 import getPathDetails from "../utils/getReplyPath";
 
 export default function useReplyMutation(toEditId) {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (post) =>
-      toEditId ? updatePost(post, toEditId) : createPost(post),
+    mutationFn: async (post) => {
+      const transformed = transform(post, (res, val, key) => {
+        res[key] = isPlainObject(val) ? JSON.stringify(val) : val;
+      });
+      return (await toEditId)
+        ? updatePost(transformed, toEditId)
+        : createPost(transformed);
+    },
     onSuccess: (data) => {
       //test against regex since React Query is unreliably switching between returning strings and booleans
       let { originalPostId, replyPath } = getPathDetails(data);


### PR DESCRIPTION
Currently, a reply's descendants disappear whenever it is edited. This is because the parent reply's descendants are not being set when it is updated. This PR fixes the issue by introducing the following changes:
- On frontend, pass replies to useReplyMutation hook
- On frontend, convert nested JSON to JSON strings before firing mutation in useReplyMutation hook
- Parse nested JSON in post entity
- Update test suite for posts entity