### PR TITLE
Fix issues with user being cleared upon account deletion

### DIFF
--- a/backend/src/apps/users/entry-points/api/delete/delete-user.js
+++ b/backend/src/apps/users/entry-points/api/delete/delete-user.js
@@ -4,10 +4,6 @@ export default function makeDeleteUser({ removeUser }) {
     try {
       let { userId } = httpRequest.user;
       const deleted = await removeUser(userId);
-      withErrorHandling(
-        () => httpRequest.logOut,
-        () => httpRequest.session.destroy
-      )("Logout unsuccessful: could not clear session.");
       return {
         headers: {
           "Content-Type": "application/json",

--- a/frontend/dist/output.css
+++ b/frontend/dist/output.css
@@ -611,12 +611,20 @@ h1,
   margin-right: 0.25rem;
 }
 
+.mr-10 {
+  margin-right: 2.5rem;
+}
+
 .mr-2 {
   margin-right: 0.5rem;
 }
 
 .mr-3 {
   margin-right: 0.75rem;
+}
+
+.mr-5 {
+  margin-right: 1.25rem;
 }
 
 .mt-1 {
@@ -768,10 +776,6 @@ h1,
   width: 1.25rem;
 }
 
-.w-5\/6 {
-  width: 83.333333%;
-}
-
 .w-6 {
   width: 1.5rem;
 }
@@ -816,16 +820,20 @@ h1,
   min-width: 10em;
 }
 
+.min-w-\[30\%\] {
+  min-width: 30%;
+}
+
 .min-w-\[80\%\] {
   min-width: 80%;
 }
 
-.max-w-\[45\%\] {
-  max-width: 45%;
-}
-
 .max-w-\[15em\] {
   max-width: 15em;
+}
+
+.max-w-\[45\%\] {
+  max-width: 45%;
 }
 
 .flex-1 {
@@ -838,10 +846,6 @@ h1,
 
 .shrink-0 {
   flex-shrink: 0;
-}
-
-.grow {
-  flex-grow: 1;
 }
 
 @keyframes pulse {
@@ -992,11 +996,6 @@ h1,
 .border-blue-300 {
   --tw-border-opacity: 1;
   border-color: rgb(147 197 253 / var(--tw-border-opacity));
-}
-
-.border-blue-800 {
-  --tw-border-opacity: 1;
-  border-color: rgb(30 64 175 / var(--tw-border-opacity));
 }
 
 .border-red-300 {
@@ -1604,16 +1603,12 @@ body {
     position: absolute;
   }
 
+  .md\:mb-0 {
+    margin-bottom: 0px;
+  }
+
   .md\:ml-5 {
     margin-left: 1.25rem;
-  }
-
-  .md\:mr-1 {
-    margin-right: 0.25rem;
-  }
-
-  .md\:mr-10 {
-    margin-right: 2.5rem;
   }
 
   .md\:mr-5 {
@@ -1632,8 +1627,8 @@ body {
     display: none;
   }
 
-  .md\:w-5\/6 {
-    width: 83.333333%;
+  .md\:w-11\/12 {
+    width: 91.666667%;
   }
 
   .md\:w-\[25\%\] {
@@ -1646,10 +1641,6 @@ body {
 
   .md\:w-auto {
     width: auto;
-  }
-
-  .md\:w-11\/12 {
-    width: 91.666667%;
   }
 
   .md\:flex-row {
@@ -1678,10 +1669,6 @@ body {
 
   .md\:justify-end {
     justify-content: flex-end;
-  }
-
-  .md\:justify-between {
-    justify-content: space-between;
   }
 
   .md\:gap-0 {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -36,6 +36,7 @@ const App = () => {
     }
     if (error && user) {
       setUser(null);
+      setVoteHistory({});
     }
   }, [data, error]);
   const router = createBrowserRouter(

--- a/frontend/src/features/profiles/components/DeletePrompt.jsx
+++ b/frontend/src/features/profiles/components/DeletePrompt.jsx
@@ -36,7 +36,7 @@ const DeletePrompt = ({ activeContext, disabled }) => {
           statusMsg: "Account has been deleted. Feel free to log out.",
         },
       });
-      navigate(".", { relative: "path" });
+      navigate("/logout");
     } else if (deleteStatus === "error") {
       statusDispatch({
         type: "UPDATE_STATUS",

--- a/frontend/src/features/profiles/hooks/useUserDelete.js
+++ b/frontend/src/features/profiles/hooks/useUserDelete.js
@@ -1,14 +1,9 @@
-import { useQueryClient, useMutation } from "@tanstack/react-query";
+import { useMutation } from "@tanstack/react-query";
 import { deleteUser } from "../services";
 
-export default function useUserUpdate() {
-  const queryClient = useQueryClient();
+export default function useUserDelete() {
   return useMutation({
     mutationFn: (userId) => deleteUser(userId),
-    onSuccess: (data) => {
-      queryClient.invalidateQueries(["posts"]);
-      queryClient.invalidateQueries(["user"]);
-    },
     retry: 0,
   });
 }


### PR DESCRIPTION
Currently, the deleteUser controller is responsible for deleting the user account in the database _and_ ensuring that the user's session information is cleared. This violates the single-responsibility principle and duplicates code unnecessarily. Additionally, the UI experience becomes inconsistent afterwards. For instance, the VoteDisplay component continues to display stale information despite the query having been refetched.
To fix these issues, this PR introduces the following changes:
- Redirect user to logout page on successful user account deletion
- Completely reset auth state and session storage when useUser returns error while user is logged in
- - This is to ensure that the frontend stays in sync with the backend. If there is an error retrieving the currently logged-in user for any reason, the frontend should not assume that the user is still logged in. Rather, it should clear the user on the frontend, since the backend no longer recognizes the logged-in user either.