### PR TITLE
Add user profile retrieval functionality on backend

### DIFF
--- a/backend/nginx/default.dev.conf
+++ b/backend/nginx/default.dev.conf
@@ -10,7 +10,7 @@ server {
         proxy_pass http://posts:3000/;
     }
 
-    location /api/auth/ {
+    location /api/users/ {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header Host $http_host;

--- a/backend/nginx/default.prod.conf
+++ b/backend/nginx/default.prod.conf
@@ -55,7 +55,7 @@ server {
             # enable strict transport security only if you understand the implications
         }
 
-        location /api/auth/ {
+        location /api/users/ {
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/backend/src/apps/users/__test__/fixtures/mock-db.js
+++ b/backend/src/apps/users/__test__/fixtures/mock-db.js
@@ -33,6 +33,18 @@ let deleteSpy = vi.fn((user) => {
   };
 });
 
+let selectSpy = vi.fn((user) => {
+  return {
+    eq: vi.fn((_, userId) => {
+      return {
+        select: vi.fn(() => {
+          return { data: [makeFakeRawUser({ userId })], error: null };
+        }),
+      };
+    }),
+  };
+});
+
 let uploadBucketSpy = vi.fn(async () => {});
 
 const mockTestDbClient = {
@@ -50,6 +62,7 @@ const mockTestDbClient = {
       update: updateSpy,
       upsert: upsertSpy,
       delete: deleteSpy,
+      select: selectSpy,
     };
   }),
 };

--- a/backend/src/apps/users/authentication/authentication-strategies/github-strategy.js
+++ b/backend/src/apps/users/authentication/authentication-strategies/github-strategy.js
@@ -6,7 +6,7 @@ export default function buildGithubStrategy({
     {
       clientID: process.env.GITHUB_CLIENT_ID,
       clientSecret: process.env.GITHUB_CLIENT_SECRET,
-      callbackURL: `/api/auth${process.env.GITHUB_CALLBACK_URL}`,
+      callbackURL: `/api/users/auth${process.env.GITHUB_CALLBACK_URL}`,
     },
     verificationCallback
   );

--- a/backend/src/apps/users/authentication/authentication-strategies/google-strategy.js
+++ b/backend/src/apps/users/authentication/authentication-strategies/google-strategy.js
@@ -6,7 +6,7 @@ export default function buildGoogleStrategy({
     {
       clientID: process.env.GOOGLE_CLIENT_ID,
       clientSecret: process.env.GOOGLE_CLIENT_SECRET,
-      callbackURL: `/api/auth${process.env.GOOGLE_CALLBACK_URL}`,
+      callbackURL: `/api/users/auth${process.env.GOOGLE_CALLBACK_URL}`,
     },
     verificationCallback
   );

--- a/backend/src/apps/users/data-access/users-db.js
+++ b/backend/src/apps/users/data-access/users-db.js
@@ -1,6 +1,5 @@
 export default function buildUsersDb({ dbClient }) {
-  return Object.freeze({ upsert, update, remove });
-
+  return Object.freeze({ getById, upsert, update, remove });
   async function update({
     userId,
     email,
@@ -48,6 +47,15 @@ export default function buildUsersDb({ dbClient }) {
       .select(
         "userId:uid, name, email, profilePic:profile_pic, voteHistory:users_votes_view(upvoted, downvoted), displayName:display_name, avatar, linkedin, twitter, bio"
       );
+    return { ...result, data: formatProfile(result.data) };
+  }
+  async function getById(userId) {
+    let result = await dbClient
+      .from("users")
+      .select(
+        "userId:uid, name, email, profilePic:profile_pic, voteHistory:users_votes_view(upvoted, downvoted), displayName:display_name, avatar, linkedin, twitter, bio"
+      )
+      .eq("uid", userId);
     return { ...result, data: formatProfile(result.data) };
   }
   function formatVoteHistory(voteHistory) {

--- a/backend/src/apps/users/data-access/users-db.spec.js
+++ b/backend/src/apps/users/data-access/users-db.spec.js
@@ -11,6 +11,13 @@ describe("Users database tests", () => {
   afterEach(() => {
     vi.restoreAllMocks();
   });
+  test("successfully retrieves a user", async () => {
+    const toGet = makeFakeRawUser();
+    const userId = { toGet };
+    const expected = { data: [toGet], error: null };
+    const actual = await usersDb.getById(userId);
+    expect(actual).toEqual(expected);
+  });
   test("successfully upserts a user", async () => {
     const toInsert = makeFakeRawUser();
     await usersDb.upsert(toInsert);

--- a/backend/src/apps/users/domain/use-cases/index.js
+++ b/backend/src/apps/users/domain/use-cases/index.js
@@ -1,24 +1,29 @@
-import makeUser from "../entities/user/index.js";
+import { imagesDb, usersDb, sessionsCache } from "../../data-access/index.js";
 import makeSaveUser from "./save-user.js";
 import makeRemoveUser from "./remove-user.js";
 import makeHandlePicture from "./handle-picture.js";
-import { imagesDb, usersDb, sessionsCache } from "../../data-access/index.js";
 import makeCacheUser from "./cache-user.js";
 import makeUncacheUser from "./uncache-user.js";
-const saveUser = makeSaveUser({
-  usersDb,
-  makeUser,
-});
+import makeRetrieveUser from "./retrieve-user.js";
+const retrieveUser = makeRetrieveUser({ usersDb });
+const saveUser = makeSaveUser({ usersDb });
 const cacheUser = makeCacheUser({ sessionsCache });
 const uncacheUser = makeUncacheUser({ sessionsCache });
 const removeUser = makeRemoveUser({ usersDb });
+const handlePicture = makeHandlePicture({ imagesDb });
 const authenticationService = Object.freeze({
   saveUser,
   cacheUser,
   uncacheUser,
   removeUser,
+  retrieveUser,
 });
-const handlePicture = makeHandlePicture({ imagesDb });
-
 export default authenticationService;
-export { saveUser, cacheUser, uncacheUser, handlePicture, removeUser };
+export {
+  saveUser,
+  cacheUser,
+  uncacheUser,
+  handlePicture,
+  removeUser,
+  retrieveUser,
+};

--- a/backend/src/apps/users/domain/use-cases/retrieve-user.js
+++ b/backend/src/apps/users/domain/use-cases/retrieve-user.js
@@ -1,0 +1,15 @@
+import makeUser from "../entities/user/index.js";
+export default function makeRetrieveUser({ usersDb }) {
+  return async function retrieveUser(userId) {
+    let { data, error } = await usersDb.getById(userId);
+    if (error) {
+      throw new Error(`User could not be retrieved: ${error.message}`);
+    }
+    if (!data) {
+      throw new Error("No such user exists.");
+    }
+    const retrievedUser = makeUser({ ...data[0] });
+
+    return retrievedUser.getDTO();
+  };
+}

--- a/backend/src/apps/users/domain/use-cases/retrieve-user.spec.js
+++ b/backend/src/apps/users/domain/use-cases/retrieve-user.spec.js
@@ -1,0 +1,32 @@
+import { vi, expect, describe, test, afterEach } from "vitest";
+import { usersDb } from "../../data-access";
+import { makeFakeRawUser } from "../../__test__/fixtures/user";
+import { retrieveUser } from ".";
+vi.mock("../../data-access");
+
+describe("User retrieval tests", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const userToRetrieve = makeFakeRawUser();
+  const { userId } = userToRetrieve;
+  test("Removes user successfully", async () => {
+    usersDb.getById.mockResolvedValue({ data: [userToRetrieve], error: null });
+    const actual = await retrieveUser(userId);
+    expect(actual).toEqual(userToRetrieve);
+  });
+
+  test("Throws error if user details are not found", async () => {
+    usersDb.getById.mockResolvedValue({ data: null, error: null });
+    expect(retrieveUser(userId)).rejects.toThrow("No such user exists.");
+  });
+
+  test("Throws error when database get operation fails", async () => {
+    let error = { message: "Database operation error" };
+    usersDb.getById.mockResolvedValue({ data: null, error });
+    expect(retrieveUser(userId)).rejects.toThrow(
+      `User could not be retrieved: ${error.message}`
+    );
+  });
+});

--- a/backend/src/apps/users/entry-points/api/auth-controller.js
+++ b/backend/src/apps/users/entry-points/api/auth-controller.js
@@ -1,10 +1,8 @@
 /* istanbul ignore file */
 import {
   saveUser,
-  handlePicture,
   cacheUser,
   uncacheUser,
-  removeUser,
 } from "../../domain/use-cases/index.js";
 import authenticator from "../../domain/services/authenticator/index.js";
 import makeGetGoogleAuth from "./get/get-google-auth.js";
@@ -13,8 +11,6 @@ import makeGetGithubAuthCallback from "./get/get-github-auth-callback.js";
 import makeGetGoogleAuthCallback from "./get/get-google-auth-callback.js";
 import makeGetAuthSuccess from "./get/get-auth-success.js";
 import makePostLogout from "./post/post-logout.js";
-import makePatchUser from "./patch/patch-user.js";
-import makeDeleteUser from "./delete/delete-user.js";
 
 const { authGoogle, authGoogleCallback, authGithub, authGithubCallback } =
   authenticator;
@@ -30,20 +26,17 @@ const getGithubAuthCallback = makeGetGithubAuthCallback({
 
 const getAuthSuccess = makeGetAuthSuccess({ cacheUser });
 const postLogout = makePostLogout({ uncacheUser });
-const patchUser = makePatchUser({ saveUser, handlePicture });
-const deleteUser = makeDeleteUser({ removeUser });
-const userController = Object.freeze({
+const authController = Object.freeze({
   getGoogleAuth,
   getGoogleAuthCallback,
   getGithubAuth,
   getGithubAuthCallback,
   getAuthSuccess,
   postLogout,
-  patchUser,
-  deleteUser,
+  saveUser,
 });
 
-export default { userController };
+export default { authController };
 
 export {
   getGoogleAuth,
@@ -52,6 +45,5 @@ export {
   getGithubAuthCallback,
   getAuthSuccess,
   postLogout,
-  patchUser,
-  deleteUser,
+  saveUser,
 };

--- a/backend/src/apps/users/entry-points/api/auth-routes.js
+++ b/backend/src/apps/users/entry-points/api/auth-routes.js
@@ -1,0 +1,19 @@
+import express from "express";
+import {
+  getGoogleAuth,
+  getGithubAuth,
+  getGoogleAuthCallback,
+  getGithubAuthCallback,
+  getAuthSuccess,
+  postLogout,
+} from "./auth-controller.js";
+import makeExpressCallback from "../../express-callback/index.js";
+
+const router = express.Router();
+router.get("/google", getGoogleAuth);
+router.get("/github", getGithubAuth);
+router.get(process.env.GOOGLE_CALLBACK_URL, getGoogleAuthCallback);
+router.get(process.env.GITHUB_CALLBACK_URL, getGithubAuthCallback);
+router.get("/success", makeExpressCallback(getAuthSuccess));
+router.post("/logout", makeExpressCallback(postLogout));
+export default router;

--- a/backend/src/apps/users/entry-points/api/get/get-user.js
+++ b/backend/src/apps/users/entry-points/api/get/get-user.js
@@ -1,0 +1,27 @@
+export default function makeGetUser({ retrieveUser }) {
+  return async function getUser(httpRequest) {
+    try {
+      let { userId } = httpRequest.params || httpRequest.user;
+      console.log(httpRequest.params, httpRequest.user);
+      if (!userId)
+        throw new Error("Error retrieving user: no user ID provided.");
+      const user = await retrieveUser(userId);
+      return {
+        headers: {
+          "Content-Type": "application/json",
+        },
+        statusCode: 200,
+        body: { user },
+      };
+    } catch (e) {
+      //TODO: Error logging
+      console.log(e);
+
+      return {
+        headers: { "Content-Type": "application/json" },
+        statusCode: 400,
+        body: { error: e.message },
+      };
+    }
+  };
+}

--- a/backend/src/apps/users/entry-points/api/get/get-user.spec.js
+++ b/backend/src/apps/users/entry-points/api/get/get-user.spec.js
@@ -1,0 +1,71 @@
+import { describe, expect, beforeEach, afterEach, vi, test } from "vitest";
+import makeFakeSession from "../../../__test__/fixtures/session";
+import { makeFakeRawUser } from "../../../__test__/fixtures/user";
+import makeGetUser from "./get-user";
+
+describe("Controller for GET to /user endpoint", () => {
+  let retrieveUser = vi.fn(() => makeFakeRawUser());
+  let getUser;
+  beforeEach(() => {
+    getUser = makeGetUser({ retrieveUser });
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+  const user = makeFakeRawUser();
+  const { userId } = user;
+  let request = {
+    params: { userId },
+  };
+  test("Returns success response if user found", async () => {
+    const expected = {
+      headers: {
+        "Content-Type": "application/json",
+      },
+      statusCode: 200,
+      body: {
+        user,
+      },
+    };
+    const actual = await getUser(request);
+    expect(actual).toEqual(expected);
+  });
+  test("Returns expected response error when exception is thrown", async () => {
+    const error = {
+      message: "Error thrown by GET /:id controller",
+    };
+    retrieveUser.mockImplementation(async () => {
+      throw new Error(error.message);
+    });
+    const expected = {
+      headers: {
+        "Content-Type": "application/json",
+      },
+      statusCode: 400,
+      body: error,
+    };
+    const actual = await getUser(request);
+    expect(actual).toEqual(expected);
+  });
+  test("Uses userId in session user object, if no userId passed via params", async () => {
+    request = { user };
+    await getUser(request);
+    const [userIdArg] = retrieveUser.mock.calls;
+    expect(userIdArg).toEqual(user.userId);
+  });
+  test("Throws error if no user ID is found in session user object and params", async () => {
+    request = { user };
+    await getUser(request);
+    const [userIdArg] = retrieveUser.mock.calls;
+    expect(userIdArg).toEqual(user.userId);
+    const expected = {
+      headers: {
+        "Content-Type": "application/json",
+      },
+      statusCode: 400,
+      body: { error: "Error retrieving user: no user ID provided." },
+    };
+    const actual = await getUser(request);
+    expect(actual).toEqual(expected);
+  });
+});

--- a/backend/src/apps/users/entry-points/api/index.js
+++ b/backend/src/apps/users/entry-points/api/index.js
@@ -1,24 +1,4 @@
-import express from "express";
-import {
-  getGoogleAuth,
-  getGithubAuth,
-  getGoogleAuthCallback,
-  getGithubAuthCallback,
-  getAuthSuccess,
-  postLogout,
-  patchUser,
-  deleteUser,
-} from "./users-controller.js";
-import makeExpressCallback from "../../express-callback/index.js";
-import authMiddleware from "../../auth-middleware/index.js";
+import authRoutes from "./auth-routes.js";
+import userRoutes from "./user-routes.js";
 
-const router = express.Router();
-router.get("/google", getGoogleAuth);
-router.get("/github", getGithubAuth);
-router.get(process.env.GOOGLE_CALLBACK_URL, getGoogleAuthCallback);
-router.get(process.env.GITHUB_CALLBACK_URL, getGithubAuthCallback);
-router.get("/success", makeExpressCallback(getAuthSuccess));
-router.post("/logout", makeExpressCallback(postLogout));
-router.patch("/user", authMiddleware(true), makeExpressCallback(patchUser));
-router.delete("/user", authMiddleware(), makeExpressCallback(deleteUser));
-export default router;
+export { authRoutes, userRoutes };

--- a/backend/src/apps/users/entry-points/api/user-controller.js
+++ b/backend/src/apps/users/entry-points/api/user-controller.js
@@ -1,0 +1,22 @@
+/* istanbul ignore file */
+import {
+  saveUser,
+  handlePicture,
+  removeUser,
+  retrieveUser,
+} from "../../domain/use-cases/index.js";
+import makePatchUser from "./patch/patch-user.js";
+import makeDeleteUser from "./delete/delete-user.js";
+import makeGetUser from "./get/get-user.js";
+const patchUser = makePatchUser({ saveUser, handlePicture });
+const deleteUser = makeDeleteUser({ removeUser });
+const getUser = makeGetUser({ retrieveUser });
+const userController = Object.freeze({
+  patchUser,
+  deleteUser,
+  getUser,
+});
+
+export default { userController };
+
+export { patchUser, deleteUser, getUser };

--- a/backend/src/apps/users/entry-points/api/user-routes.js
+++ b/backend/src/apps/users/entry-points/api/user-routes.js
@@ -1,0 +1,10 @@
+import express from "express";
+import { patchUser, deleteUser, getUser } from "./user-controller.js";
+import makeExpressCallback from "../../express-callback/index.js";
+import authMiddleware from "../../auth-middleware/index.js";
+
+const router = express.Router();
+router.patch("/", authMiddleware(true), makeExpressCallback(patchUser));
+router.delete("/", authMiddleware(), makeExpressCallback(deleteUser));
+router.get("/:userId", makeExpressCallback(getUser));
+export default router;

--- a/backend/src/apps/users/entry-points/server.js
+++ b/backend/src/apps/users/entry-points/server.js
@@ -1,6 +1,6 @@
 /* istanbul ignore file */
 import "dotenv/config";
-import userRoutes from "./api/index.js";
+import { authRoutes, userRoutes } from "./api/index.js";
 import expressFileUpload from "express-fileupload";
 import express from "express";
 import { cacheClient as redisClient } from "../data-access/index.js";
@@ -48,7 +48,8 @@ app.use(
 
 app.use(configuredPassportInstance.initialize());
 app.use(configuredPassportInstance.session());
-app.use("/", userRoutes);
+app.use("/identity", userRoutes);
+app.use("/auth", authRoutes);
 
 app.listen(process.env.PORT, () => {
   console.log("Server is listening on port ", process.env.PORT);


### PR DESCRIPTION
Currently, there is no way to retrieve any user's profile except that of the currently logged in user. As part of allowing users to view other users' profiles, this PR implements a GET endpoint to retrieve a user's profile by their ID. Since this endpoint wouldn't fit under an /auth path, this PR also changes the paths as needed to ensure that they make sense.

This PR introduces the following changes:
- Change /api/auth/ location in nginx to /api/users/
- Separate auth paths (e.g. login/logout) from regular user action paths (e.g. saving/deleting profile)
- Update redirect URIs used in authentication strategies
- Add getById function to usersDb module
- Add use case and controller for getting a user by their ID
- Update files as needed