### PR TITLE
Toggle 'disabled' status of inputs in Profile page correctly

### DIFF
--- a/frontend/src/features/profiles/components/Socials.jsx
+++ b/frontend/src/features/profiles/components/Socials.jsx
@@ -1,8 +1,8 @@
-import { useContext, useEffect } from "react";
+import { useContext } from "react";
 import { ProfileContext } from "../context/ProfileContext";
 import { StatusContext } from "../../notifications/context/StatusContext";
 import ProfileSection from "./ProfileSection";
-const Socials = () => {
+const Socials = ({ enabled }) => {
   const { profile, dispatch } = useContext(ProfileContext);
   const { status } = useContext(StatusContext);
   const handleChange = (e) =>
@@ -31,7 +31,7 @@ const Socials = () => {
               : "This user has not added their LinkedIn profile."
           }
           onChange={handleChange}
-          disabled={status === "success"}
+          disabled={!enabled}
         />
       </div>
       <div
@@ -52,7 +52,7 @@ const Socials = () => {
               : "This user has not added their Twitter profile."
           }
           onChange={handleChange}
-          disabled={status === "success"}
+          disabled={!enabled}
         />
       </div>
     </ProfileSection>


### PR DESCRIPTION
Currently, the inputs in the Socials component are being disabled even when the user is viewing their own profile. The intended behavior is that the user should be able to edit these inputs if they are viewing their own profile.
This PR fixes the issue by introducing the following change:
- Use enabled prop passed by ProfileDetails to toggle disabled status