### PR TITLE
Remove highlight from vote buttons when user switches vote

### DIFF
--- a/frontend/src/features/votes/components/DownvoteButton.jsx
+++ b/frontend/src/features/votes/components/DownvoteButton.jsx
@@ -19,7 +19,7 @@ const DownvoteButton = ({ postId, setUpvoteCount, voteContext }) => {
     e.preventDefault();
     if (userId) {
       let adjustment = downvoted.has(postId) ? 1 : -1;
-      setCurrentVote((prev) => (prev === -1 ? 0 : -1));
+      setCurrentVote((prev) => (prev === -1 || upvoted.has(postId) ? 0 : -1));
       setUpvoteCount((prev) => prev + adjustment);
       downvote({ postId, userId, voteCount: adjustment });
     }

--- a/frontend/src/features/votes/components/UpvoteButton.jsx
+++ b/frontend/src/features/votes/components/UpvoteButton.jsx
@@ -19,7 +19,7 @@ const UpvoteButton = ({ voteContext, postId, setUpvoteCount }) => {
     e.preventDefault();
     if (userId) {
       let adjustment = upvoted.has(postId) ? -1 : 1;
-      setCurrentVote((prev) => (prev === 1 ? 0 : 1));
+      setCurrentVote((prev) => (prev === 1 || downvoted.has(postId) ? 0 : 1));
       setUpvoteCount((prev) => prev + adjustment);
       upvote({ postId, userId, voteCount: adjustment });
     }

--- a/frontend/src/features/votes/components/VoteDisplay.jsx
+++ b/frontend/src/features/votes/components/VoteDisplay.jsx
@@ -10,7 +10,7 @@ const VoteDisplay = ({ existingUpvoteCount }) => {
   const [upvoteCount, setUpvoteCount] = useState(existingUpvoteCount);
   const [currentVote, setCurrentVote] = useState(0);
   return (
-    <div className="flex flex-col max-w-auto h-full rounded-lg justify-center items-center">
+    <div className="flex flex-row md:flex-col w-1/5 gap-2 md:w-auto max-w-auto rounded-lg items-center md:gap-0 justify-between md:justify-center">
       <UpvoteButton
         postId={postId}
         setUpvoteCount={setUpvoteCount}


### PR DESCRIPTION
Currently, when a user casts a vote opposite of the one they had previously chosen (e.g. switches from upvote to downvote), the new vote button is highlighted. For example, if a user clicked the downvote button after clicking the upvote button, the downvote button will be highlighted. To the user, it would appear that they have now actively downvoted the post. 

However, behind the scenes, such an action _cancels_ the existing vote, rather than adding a new one. This means that the user should not see any highlighting, since their voting decision has been reset to neutral. If the user refreshed the page, they would see no highlights, which accurately represents their voting state.

Accordingly, this PR ensures that the UI also resets the current vote state when such an action happens. The change introduced is:
- Set voteCount state variable to 0 when user casts opposite vote (thereby cancelling current vote)