### PR TITLE
Remove React warning about incorrect attribute usage on Tooltip component

### DIFF
--- a/frontend/src/components/Tooltip.jsx
+++ b/frontend/src/components/Tooltip.jsx
@@ -3,7 +3,7 @@ const Tooltip = ({ content, ariaId }) => {
     <div
       role="tooltip"
       id={ariaId}
-      class="group-hover/tooltip:opacity-100 transition-opacity bg-gray-800 p-1 text-xs text-center text-gray-100 rounded-md absolute left-1/2 
+      className="group-hover/tooltip:opacity-100 transition-opacity bg-gray-800 p-1 text-xs text-center text-gray-100 rounded-md absolute left-1/2 
 -translate-x-1/2 opacity-0 m-1 mx-auto w-fit whitespace-nowrap"
     >
       {content}


### PR DESCRIPTION
Currently, React displays a warning about the Tooltip component using the HTML attribute 'class' rather than the JSX attribute 'className'. This PR fixes that issue by introducing the following change:

- Replace 'class' with 'className' in Tooltip component