### PR TITLE
Stop post replies from disappearing after post is updated

### DIFF
--- a/frontend/src/features/posts/hooks/usePostMutation.js
+++ b/frontend/src/features/posts/hooks/usePostMutation.js
@@ -8,7 +8,10 @@ export default function usePostMutation(toEditId) {
       toEditId ? updatePost(post, toEditId) : createPost(post),
     onSuccess: (data) => {
       if (toEditId) {
-        queryClient.setQueryData(["post", toEditId], (oldData) => data.updated);
+        console.log(data.updated);
+        queryClient.setQueryData(["post", toEditId], (oldData) => {
+          return { ...data.updated, replies: oldData.replies };
+        });
       } else {
         queryClient.setQueryData(
           ["post", data.posted.id],


### PR DESCRIPTION
Currently, post replies disappear after the post is updated. This is because the React mutation query used to update the query cache replaces the cached version of the post with the one that is returned from the backend. However, since the database does not refetch all replies for the post, and only returns the updated post itself, this causes the replies to disappear from view. Until the post query is refetched (e.g. by the user refreshing the page), they cannot be viewed.

This PR fixes the issue by introducing the following change:
- Ensure post mutation hook copies replies from cached version of post to newer version of post 