### PR TITLE
Fix Tiptap editor responsiveness and pre-fill issues

### DIFF
--- a/frontend/src/components/rich-textarea/MenuBar.jsx
+++ b/frontend/src/components/rich-textarea/MenuBar.jsx
@@ -5,7 +5,7 @@ const MenuBar = ({ editor }) => {
     return null;
   }
   return (
-    <div className="flex w-full gap-3 bg-slate-50 rounded-t menu-bar">
+    <div className="flex w-full gap-2 bg-slate-50 rounded-t menu-bar">
       <MenuBarButton
         onClick={() => editor.chain().focus().toggleBold().run()}
         disabled={!editor.can().chain().focus().toggleBold().run()}
@@ -73,21 +73,21 @@ const MenuBar = ({ editor }) => {
       <MenuBarButton
         onClick={() => editor.chain().focus().toggleBlockquote().run()}
         activeArgs={["blockquote"]}
-        className="hidden md:block"
+        className="hidden lg:block"
         editor={editor}
       >
         <i className="ri-quote-text text-s"></i>
       </MenuBarButton>
       <MenuBarButton
         onClick={() => editor.chain().focus().setHorizontalRule().run()}
-        className="hidden md:block"
+        className="hidden lg:block"
         editor={editor}
       >
         <i className="ri-separator text-s"></i>
       </MenuBarButton>
       <MenuBarButton
         onClick={() => editor.chain().focus().setHardBreak().run()}
-        className="hidden md:block"
+        className="hidden lg:block"
         editor={editor}
       >
         <i className="ri-text-wrap text-s"></i>{" "}
@@ -95,7 +95,7 @@ const MenuBar = ({ editor }) => {
       <MenuBarButton
         onClick={() => editor.chain().focus().undo().run()}
         disabled={!editor.can().chain().focus().undo().run()}
-        className="hidden md:block"
+        className="hidden lg:block"
         editor={editor}
       >
         <i className="ri-arrow-go-back-line text-s"></i>
@@ -104,7 +104,7 @@ const MenuBar = ({ editor }) => {
         onClick={() => editor.chain().focus().redo().run()}
         disabled={!editor.can().chain().focus().redo().run()}
         editor={editor}
-        className="hidden md:block disabled:bg-gray-200"
+        className="hidden lg:block disabled:bg-gray-200"
       >
         <i className="ri-arrow-go-forward-line text-s"></i>{" "}
       </MenuBarButton>

--- a/frontend/src/features/replies/components/form/ReplyForm.jsx
+++ b/frontend/src/features/replies/components/form/ReplyForm.jsx
@@ -41,7 +41,9 @@ const ReplyForm = ({ original, user }) => {
         <div className="rounded border border-slate-800 flex w-full  flex-col">
           <Textarea
             onChange={(content) => setPost({ ...post, postContent: content })}
-            initialContent={original?.postContent}
+            initialContent={
+              replyForm.mode === "edit" ? original?.postContent : null
+            }
           />
         </div>
         <ReplyFormOptions clear={clear} post={post} />


### PR DESCRIPTION
Currently, the MenuBar displays certain buttons only on medium-sized screens and larger. However, smaller medium-sized screens are not able to contain all the MenuBar buttons, causing an overflow. Additionally, the editor can sometimes be pre-filled with a parent post's content when the user intends to reply to the post.
To fix these issues, this PR introduces the following changes:
- In medium-sized screens, limit number of buttons displayed on editor menu bar
- Pre-fill ReplyForm with original post's content only if reply form is in edit mode