### PR TITLE
Improve post form input validation

### DIFF
--- a/frontend/src/features/posts/components/form/PostForm.jsx
+++ b/frontend/src/features/posts/components/form/PostForm.jsx
@@ -51,10 +51,26 @@ const PostForm = ({ toEditId, user, postToEdit }) => {
     });
   };
 
+  const validate = () => {
+    toast.dismiss();
+    if (!post.title?.trim()) {
+      toast.error("Please enter a title.");
+      return false;
+    }
+    if (!post.postContent?.trim()) {
+      toast.error("Please add content to your post.");
+      return false;
+    }
+    if (!toEditId && !post.file) {
+      toast.error("Please attach a file.");
+      return false;
+    }
+    return true;
+  };
   const handleSubmit = (e) => {
     e.preventDefault();
 
-    if (toEditId || post.file) {
+    if (validate()) {
       toast.promise(submit({ ...post, id: toEditId }), {
         loading: "Preparing your post.",
         success: ({ posted, updated }) => {
@@ -74,8 +90,6 @@ const PostForm = ({ toEditId, user, postToEdit }) => {
         },
         error: (error) => error.message,
       });
-    } else {
-      toast.error("Please attach a file.");
     }
   };
 


### PR DESCRIPTION
Currently, the title and post content fields in the post form lack input validation, and invalid inputs are intercepted by the server. However, fewer server requests would take place if input validation was handled on the frontend. 

Accordingly, this PR makes the following change:
- Ensure title and content fields are valid before making a request to server
- Display error toast if validation fails