### PR TITLE
Ensure AccountActions buttons show up when user is viewing their own profile

### DIFF
--- a/frontend/src/pages/Profile.jsx
+++ b/frontend/src/pages/Profile.jsx
@@ -15,10 +15,7 @@ const Profile = () => {
     status,
     error,
   } = useUserProfile(toRetrieveId, user?.userId);
-  /**
-   * if neither profile nor user exist, or if error fetching user, then
-   * use useEffect to toast error, navigate back home.
-   */
+
   useEffect(() => {
     if (error) {
       toast.error("Error loading profile.");
@@ -33,7 +30,7 @@ const Profile = () => {
         <ProfileContextProvider>
           <ProfileDetails
             user={profile || user}
-            self={user?.userId === toRetrieveId || (!profile && user?.userId)}
+            self={profile.userId === user?.userId}
           />
         </ProfileContextProvider>
       )}


### PR DESCRIPTION
Currently, the user sees the buttons to delete their account or update their account details only if their user ID is present as a route path parameter. However, the user ID parameter is optional for logged-in users, so the '/profile' route should simply display the logged-in user's profile details. Hence, the Profile page link on the Navbar for logged-in users simply sends a user to the route "/profile", without any route parameters. So the expected behavior is that a user would see all the same profile details regardless of whether the user ID parameter is present.

This issue is occurring because the Profile page uses a faulty conditional check to determine the 'self' prop, which tells ProfileDetails if the user is viewing their own profile. Currently, a user is determined to be viewing their own profile if the relevant React Query hook has not fired, or if the user ID path parameter matches the logged-in user's ID. However, the useUserProfile React Query hook has since changed, and now the query _always_ runs. So now, 'self' can simply be determined by checking if the userId returned by the query and the current user ID match. 

In summary, this PR introduces the following change:
- Fix condition used to determine 'self' prop, passed to ProfileDetails by Profile