### PR TITLE
Display prompt before deleting a post

### DIFF
--- a/frontend/src/features/posts/components/DeletePrompt.jsx
+++ b/frontend/src/features/posts/components/DeletePrompt.jsx
@@ -1,0 +1,61 @@
+import { useEffect } from "react";
+import { toast } from "react-hot-toast";
+import { usePostDeletion } from "../hooks";
+import { useInteractiveDispatch } from "../../../context/InteractiveContext";
+const DeletePrompt = ({ postId, cancel }) => {
+  const { status, mutateAsync: remove } = usePostDeletion(postId);
+  const interactiveDispatch = useInteractiveDispatch();
+  const handleConfirmDelete = () => {
+    toast.promise(remove(postId), {
+      loading: "Post is being deleted.",
+      success: "Post has been deleted. Feel free to navigate away.",
+      error: (error) => error.message,
+    });
+  };
+  useEffect(() => {
+    if (status !== "idle")
+      interactiveDispatch({ type: "UPDATE_INTERACTIVE", payload: status });
+  }, [status]);
+  return (
+    <div className="flex gap-3 p-3 rounded text-red-800 border border-red-300 rounded-lg bg-red-50 mt-2 md:mt-0">
+      <label
+        htmlFor="delete-warning"
+        className="flex items-center gap-3  text-left text-amber-800 md:mr-5 font-medium"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          strokeWidth={1.5}
+          stroke="currentColor"
+          className="w-6 h-6 pt-1 shrink-0"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z"
+          />
+        </svg>
+        <p>This will delete this post and all its replies. Continue?</p>
+      </label>
+      <div className="flex flex-col justify-between items-center gap-5 pl-3 md:pl-0 md:flex-row">
+        <button
+          className="whitespace-nowrap text-slate-50 bg-red-500 hover:bg-red-500/90 disabled:bg-red-500/50  focus:ring-4 focus:outline-none focus:ring-[#24292F]/50 font-medium rounded-lg px-3 py-2 flex items-center justify-center self-center"
+          onClick={handleConfirmDelete}
+          disabled={status === "loading"}
+        >
+          Delete Anyway
+        </button>
+        <button
+          className="text-slate-50 disabled:opacity-50 bg-amber-800 hover:bg-amber-800/90 focus:ring-4 focus:outline-none focus:ring-[#24292F]/50 font-medium rounded-lg px-3 py-2 flex items-center justify-center "
+          onClick={cancel}
+          disabled={status === "loading"}
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default DeletePrompt;

--- a/frontend/src/features/posts/components/DeletePrompt.jsx
+++ b/frontend/src/features/posts/components/DeletePrompt.jsx
@@ -1,20 +1,23 @@
 import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
 import { toast } from "react-hot-toast";
 import { usePostDeletion } from "../hooks";
 import { useInteractiveDispatch } from "../../../context/InteractiveContext";
 const DeletePrompt = ({ postId, cancel }) => {
+  const navigate = useNavigate();
   const { status, mutateAsync: remove } = usePostDeletion(postId);
   const interactiveDispatch = useInteractiveDispatch();
   const handleConfirmDelete = () => {
     toast.promise(remove(postId), {
       loading: "Post is being deleted.",
-      success: "Post has been deleted. Feel free to navigate away.",
+      success: "Post has been deleted.",
       error: (error) => error.message,
     });
   };
   useEffect(() => {
     if (status !== "idle")
       interactiveDispatch({ type: "UPDATE_INTERACTIVE", payload: status });
+    if (status === "success") navigate("/");
   }, [status]);
   return (
     <div className="flex gap-3 p-3 rounded text-red-800 border border-red-300 rounded-lg bg-red-50 mt-2 md:mt-0">

--- a/frontend/src/features/posts/components/PostOptions.jsx
+++ b/frontend/src/features/posts/components/PostOptions.jsx
@@ -1,37 +1,28 @@
-import React, { useContext, useEffect } from "react";
+import { useContext, useState } from "react";
 import { ReplyFormContext } from "../../replies/context/ReplyFormContext";
-import { usePostDeletion } from "../hooks";
 import { Link } from "react-router-dom";
-import { useInteractiveDispatch } from "../../../context/InteractiveContext";
+import { useInteractive } from "../../../context/InteractiveContext";
+import DeletePrompt from "./DeletePrompt";
 const PostOptions = ({ post, user }) => {
-  const interactiveDispatch = useInteractiveDispatch();
+  const interactive = useInteractive();
   const { replyForm, dispatch: replyFormDispatch } =
     useContext(ReplyFormContext);
-  let postId = post?.id;
-  let { status, mutateAsync: remove } = usePostDeletion(postId);
+  const [deletePromptActive, setDeletePromptActive] = useState(false);
   const handleReplyClick = () => {
     replyFormDispatch({ type: "SWITCH_REPLY_FORM_ACTIVE" });
   };
   const handleDeleteClick = () => {
-    toast.promise(remove(postId), {
-      loading: "Post is being deleted.",
-      success: "Post has been deleted. Feel free to navigate away.",
-      error: (error) => error.message,
-    });
+    setDeletePromptActive(true);
   };
-  useEffect(() => {
-    if (status !== "idle")
-      interactiveDispatch({ type: "UPDATE_INTERACTIVE", payload: status });
-  }, [status]);
 
   return (
-    <div className="w-full flex gap-2 items-stretch">
+    <div className="w-full flex gap-2 items-center flex-wrap">
       {user && (
         <>
           <button
             className={`text-slate-50 disabled:opacity-50 bg-amber-800 hover:bg-amber-800/90 focus:ring-4 focus:outline-none focus:ring-[#24292F]/50 font-medium rounded-lg px-5 py-2.5 flex items-center justify-center `}
             onClick={handleReplyClick}
-            disabled={replyForm.active || status === "loading"}
+            disabled={replyForm.active || !interactive}
           >
             Reply
           </button>
@@ -40,19 +31,25 @@ const PostOptions = ({ post, user }) => {
               <Link to={`/edit-post/${post.id}`}>
                 <button
                   className="text-slate-50 bg-amber-800 hover:bg-amber-800/90 focus:ring-4 focus:outline-none focus:ring-[#24292F]/50 font-medium rounded-lg px-5 py-2.5 flex items-center  h-full justify-center"
-                  disabled={status === "loading"}
+                  disabled={!interactive}
                 >
                   Edit
                 </button>
               </Link>
 
               <button
-                className="text-slate-50 bg-red-500 hover:bg-red-500/90 focus:ring-4 focus:outline-none focus:ring-[#24292F]/50 font-medium rounded-lg px-5 py-2.5 flex items-center justify-center"
+                className="text-slate-50 bg-red-500 disabled:bg-red-500/50 hover:bg-red-500/90 focus:ring-4 focus:outline-none focus:ring-[#24292F]/50 font-medium rounded-lg px-5 py-2.5 flex items-center justify-center"
                 onClick={handleDeleteClick}
-                disabled={status === "loading"}
+                disabled={deletePromptActive || !interactive}
               >
                 Delete
               </button>
+              {deletePromptActive && (
+                <DeletePrompt
+                  postId={post.id}
+                  cancel={() => setDeletePromptActive(false)}
+                />
+              )}
             </>
           )}
         </>

--- a/frontend/src/features/replies/components/form/ReplyFormOptions.jsx
+++ b/frontend/src/features/replies/components/form/ReplyFormOptions.jsx
@@ -50,7 +50,7 @@ const ReplyFormOptions = ({ clear, post }) => {
         <button
           type="submit"
           aria-label="Submit"
-          className="text-slate-50 text-xs bg-amber-800 hover:bg-amber-800/90 focus:ring-4 focus:outline-none focus:ring-[#24292F]/50 font-medium rounded-lg px-5 py-2.5 flex items-center justify-center"
+          className="text-slate-50 text-xs bg-amber-800 disabled:bg-amber-800/50 hover:bg-amber-800/90 focus:ring-4 focus:outline-none focus:ring-[#24292F]/50 font-medium rounded-lg px-5 py-2.5 flex items-center justify-center"
           onClick={handleSubmit}
           disabled={!interactive || replyStatus === "loading"}
         >
@@ -73,7 +73,7 @@ const ReplyFormOptions = ({ clear, post }) => {
         <button
           type="submit"
           aria-label="Cancel edit"
-          className="text-slate-50 text-xs bg-amber-800 hover:bg-amber-800/90 focus:ring-4 focus:outline-none focus:ring-[#24292F]/50 font-medium rounded-lg px-5 py-2.5 flex items-center justify-center"
+          className="text-slate-50 text-xs bg-amber-800 disabled:bg-amber-800/50 hover:bg-amber-800/90 focus:ring-4 focus:outline-none focus:ring-[#24292F]/50 font-medium rounded-lg px-5 py-2.5 flex items-center justify-center"
           onClick={close}
           disabled={!interactive || replyStatus === "loading"}
         >


### PR DESCRIPTION
Currently, the post deletion process begins as soon as the user clicks the 'Delete' button on a post. This could cause posts to be accidentally deleted. Additionally, users are allowed to stay on the post's page even after it has been deleted, which may cause confusion since replies, edits, etc. cannot be made anymore.

To address this issue, this PR  introduces the following changes:
- Add a prompt for users to confirm their intentions to delete a post
- Redirect users to main page once post is deleted
- Update styling