### PR TITLE
Refactor error handling process to common util

### DIFF
--- a/frontend/src/features/authentication/services/index.js
+++ b/frontend/src/features/authentication/services/index.js
@@ -1,11 +1,11 @@
 import axios from "axios";
-
+import withErrorHandling from "../../../utils/withErrorHandling";
 const DOMAIN = import.meta.env.DEV
   ? "http://localhost"
   : "https://cv-circle.com";
 
 const getCurrentUser = async () => {
-  try {
+  return await withErrorHandling(async () => {
     let { data } = await axios.get(`${DOMAIN}/api/users/auth/success`, {
       withCredentials: true,
       headers: {
@@ -14,33 +14,18 @@ const getCurrentUser = async () => {
         "Access-Control-Allow-Credentials": true,
       },
     });
-    let { user } = data;
-    return user;
-  } catch (e) {
-    let errorMsg = e.response?.data?.error;
-    let status = e.response?.status;
-    throw {
-      message: errorMsg || "An unknown error has happened!",
-      status: status || e.code,
-    };
-  }
+    return data.user;
+  });
 };
 const postLogout = async () => {
-  try {
+  return await withErrorHandling(async () => {
     let { data: authStatus } = await axios.post(
       `${DOMAIN}/api/users/auth/logout`,
       {},
       { withCredentials: true }
     );
     return authStatus;
-  } catch (e) {
-    let errorMsg = e.response?.data?.error;
-    let status = e.response?.status;
-    throw {
-      message: errorMsg || "An unknown error has happened!",
-      status: status || e.code,
-    };
-  }
+  });
 };
 
 const AUTH_URL_GITHUB = `${DOMAIN}/api/users/auth/github`;

--- a/frontend/src/features/posts/services/index.js
+++ b/frontend/src/features/posts/services/index.js
@@ -1,22 +1,11 @@
 import axios from "axios";
 axios.defaults.withCredentials = true;
+import withErrorHandling from "../../../utils/withErrorHandling";
+
 const DOMAIN = import.meta.env.DEV
   ? "http://localhost"
   : "https://cv-circle.com";
 
-const withErrorHandling = async (fn) => {
-  try {
-    return await fn();
-  } catch (e) {
-    console.log(e);
-    let { data, status } = e.response || {};
-    let errorMsg = data?.error;
-    throw {
-      message: errorMsg || "An unknown error has happened!",
-      status: status || e.code,
-    };
-  }
-};
 const getPost = async (postId) => {
   return await withErrorHandling(async () => {
     let { data } = await axios.get(`${DOMAIN}/api/posts/${postId}`, {
@@ -25,6 +14,7 @@ const getPost = async (postId) => {
     return data?.post;
   });
 };
+
 const getAllPosts = async () => {
   return await withErrorHandling(async () => {
     let { data } = await axios.get(`${DOMAIN}/api/posts/`, {
@@ -65,6 +55,7 @@ const votePost = async (vote) => {
     return voted;
   });
 };
+
 const deletePost = async (postId) => {
   return await withErrorHandling(async () => {
     let { data: deletedPost } = await axios.delete(

--- a/frontend/src/features/profiles/services/index.js
+++ b/frontend/src/features/profiles/services/index.js
@@ -1,22 +1,10 @@
 import axios from "axios";
+import withErrorHandling from "../../../utils/withErrorHandling";
 
 const DOMAIN = import.meta.env.DEV
   ? "http://localhost"
   : "https://cv-circle.com";
 
-const withErrorHandling = async (fn) => {
-  try {
-    return await fn();
-  } catch (e) {
-    console.log(e);
-    let { data, status } = e.response || {};
-    let errorMsg = data?.error;
-    throw {
-      message: errorMsg || "An unknown error has happened!",
-      status: status || e.code,
-    };
-  }
-};
 const getUserProfile = async (userId) => {
   return await withErrorHandling(async () => {
     let { data } = await axios.get(`${DOMAIN}/api/users/identity/${userId}`, {

--- a/frontend/src/features/replies/components/ReplyAuthorThumbnail.jsx
+++ b/frontend/src/features/replies/components/ReplyAuthorThumbnail.jsx
@@ -19,6 +19,7 @@ const PostAuthorThumbnail = ({ profile, status }) => {
           <img
             alt="Author profile picture"
             src={profile?.profilePic}
+            referrerPolicy="no-referrer"
             className="rounded-full w-full h-full "
           />
         )

--- a/frontend/src/features/votes/services/votePost.js
+++ b/frontend/src/features/votes/services/votePost.js
@@ -1,22 +1,16 @@
 import axios from "axios";
 axios.defaults.withCredentials = true;
+import withErrorHandling from "../../../utils/withErrorHandling";
 const DOMAIN = import.meta.env.DEV
   ? "http://localhost"
   : "https://cv-circle.com";
 export default async function votePost(vote) {
-  try {
+  return await withErrorHandling(async () => {
     let { data: voted } = await axios.post(`${DOMAIN}/api/posts/vote`, vote, {
       headers: {
         "Content-Type": "multipart/form-data",
       },
     });
     return voted;
-  } catch (e) {
-    let { data, status } = e.response;
-    let errorMsg = data.error;
-    throw {
-      message: errorMsg || "An unknown error has happened!",
-      status: status || e.code,
-    };
-  }
+  });
 }

--- a/frontend/src/utils/withErrorHandling.js
+++ b/frontend/src/utils/withErrorHandling.js
@@ -1,0 +1,12 @@
+export default async (fn) => {
+  try {
+    return await fn();
+  } catch (e) {
+    let { data, status } = e.response || {};
+    let errorMsg = data?.error;
+    throw {
+      message: errorMsg || "An unknown error has happened!",
+      status: status || e.code,
+    };
+  }
+};


### PR DESCRIPTION
Currently, the same error-handling logic is used across multiple service files. It is often declared in each service file as a function named 'withErrorHandling'. This PR fixes that by introducing the following change:
- Refactor withErrorHandling to common util