### PR TITLE
Ensure posts list on main page updates with new vote count after vote changes

### DIFF
--- a/frontend/src/features/votes/components/VoteDisplay.jsx
+++ b/frontend/src/features/votes/components/VoteDisplay.jsx
@@ -1,14 +1,24 @@
 import React from "react";
-import { useState } from "react";
-import { useParams, useOutletContext } from "react-router-dom";
+import { useState, useEffect } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { useParams } from "react-router-dom";
 import UpvoteButton from "./UpvoteButton";
 import DownvoteButton from "./DownvoteButton";
 
 const VoteDisplay = ({ existingUpvoteCount }) => {
-  const [user] = useOutletContext();
+  const queryClient = useQueryClient();
   const { id: postId } = useParams();
   const [upvoteCount, setUpvoteCount] = useState(existingUpvoteCount);
   const [currentVote, setCurrentVote] = useState(0);
+  useEffect(() => {
+    queryClient.setQueryData(["posts"], (posts) =>
+      posts?.reduce((allPosts, currentPost) => {
+        if (currentPost.id.toString() === postId)
+          currentPost = { ...currentPost, upvoteCount };
+        return [...allPosts, currentPost];
+      }, [])
+    );
+  }, [upvoteCount]);
   return (
     <div className="flex flex-row md:flex-col w-1/5 gap-2 md:w-auto max-w-auto rounded-lg items-center md:gap-0 justify-between md:justify-center">
       <UpvoteButton


### PR DESCRIPTION
Currently, the posts list on the main page does not refresh a post's total vote count after the user changes or places a vote. This is because the posts are cached using React Query, and nothing updates the main posts list's cache after a user's vote changes.

This PR resolves the issue by making the following change:
- Update cached data for posts list with new vote information after user changes/places a vote